### PR TITLE
Add doc check to tox env, fix exists doc check errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.py[cod]
+__cache__
+.cache
 
 # C extensions
 *.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: python
 python:
   - '2.7'
-sudo: false
+sudo: required
+dist: trusty
 env:
   - TOX_ENV=static_check
+  - TOX_ENV=doc_check
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y pkg-config libvirt-dev libvirt-bin python-dev
 install: pip install tox
 script: tox -e $TOX_ENV

--- a/mos_tests/heat/heat_tests.py
+++ b/mos_tests/heat/heat_tests.py
@@ -65,10 +65,11 @@ class HeatIntegrationTests(unittest.TestCase):
 
     def test_543328_HeatResourceTypeList(self):
         """ This test case checks list of available Heat resources.
+
             Steps:
-             1. Get list of Heat resources.
-             2. Check count of resources.
-             3. Check that list of resources contains required resources.
+                1. Get list of Heat resources.
+                2. Check count of resources.
+                3. Check that list of resources contains required resources.
         """
         resource_types = [r.resource_type for r in
                           self.heat.resource_types.list()]
@@ -85,14 +86,15 @@ class HeatIntegrationTests(unittest.TestCase):
     def test_543347_HeatCreateStack(self):
         """ This test performs creation of a new stack with
             a help of Heat. And then delete it.
+
             Steps:
-            1. Read template from URL
-            2. Create new stack.
-                + Check that stack became from
-                  'CREATE_IN_PROGRESS' --> 'CREATE_COMPLETE'
-            3. Delete created stack
-                + Check that stack became from
-                  'DELETE_IN_PROGRESS' --> 'DELETE_COMPLETE'
+                1. Read template from URL
+                2. Create new stack.
+                    + Check that stack became from
+                      'CREATE_IN_PROGRESS' --> 'CREATE_COMPLETE'
+                3. Delete created stack
+                    + Check that stack became from
+                      'DELETE_IN_PROGRESS' --> 'DELETE_COMPLETE'
 
         https://mirantis.testrail.com/index.php?/cases/view/543347
         [Alexander Koryagin]
@@ -184,9 +186,11 @@ class HeatIntegrationTests(unittest.TestCase):
 
     def test_543329_HeatResourceTypeShow(self):
         """ This test case checks representation of all Heat resources.
+
             Steps:
-             1. Get list of Heat resources.
-             2. Check that all types of resources have correct representation.
+                1. Get list of Heat resources.
+                2. Check that all types of resources have correct \
+                    representation.
         """
         resource_types = [r.resource_type for r in
                           self.heat.resource_types.list()]
@@ -199,10 +203,11 @@ class HeatIntegrationTests(unittest.TestCase):
     def test_543330_HeatResourceTypeTemplate(self):
         """ This test case checks representation of templates for all Heat
             resources.
+
             Steps:
-             1. Get list of Heat resources.
-             2. Check that templates for all resources have correct
-                representation.
+                1. Get list of Heat resources.
+                2. Check that templates for all resources have correct
+                    representation.
         """
         resource_types = [r.resource_type for r in
                           self.heat.resource_types.list()]
@@ -214,11 +219,12 @@ class HeatIntegrationTests(unittest.TestCase):
 
     def test_543335_HeatStackDelete(self):
         """ This test case checks deletion of stack.
+
             Steps:
-             1. Create stack using template file empty_heat_templ.yaml.
-             2. Check that the stack is in the list of stacks
-             3. Delete the stack.
-             4. Check that the stack is absent in the list of stacks
+                1. Create stack using template file empty_heat_templ.yaml.
+                2. Check that the stack is in the list of stacks
+                3. Delete the stack.
+                4. Check that the stack is absent in the list of stacks
         """
         stack_name = 'empty_stack'
         if common_functions.check_stack(stack_name, self.heat):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,13 @@
 pytest
-python-keystoneclient>=0.3.2
+pytest-xdist
+tox
+sphinx==1.3.1
+requests>=2.2.0
+python-glanceclient==0.17.1
+python-keystoneclient>=2.0.0
 python-novaclient>=2.15.0
+python-cinderclient>=1.0.5
 python-neutronclient>=2.0
 python-heatclient>=0.2.12
-sphinx==1.3.1
-tox
+python-fuelclient
+git+git://github.com/openstack/fuel-devops.git@2.9.13

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=static_check
+envlist=static_check,doc_check
 skipsdist=True
 
 [testenv:static_check]
@@ -12,5 +12,11 @@ commands=
 [flake8]
 filename=*.py
 ignore = E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E251,H405
-exclude =  .venv,.git,.tox,dist,doc,*openstack/common/*,*lib/python*,*egg,build,tools/xenserver*,releasenotes
+exclude =  .venv,.git,.tox,dist,doc,*egg,build,releasenotes
 max-complexity=25
+
+[testenv:doc_check]
+deps=
+    -r{toxinidir}/requirements.txt
+commands=
+    sphinx-build -Eq -b html -d doc/_build/doctrees doc doc/_build/html


### PR DESCRIPTION
Now tox (and Travis) invocation doc build and check output errors and warnings.
Also fix existed doc build errors/warnings.
