### PR TITLE
Add testcase 'Check that VxLAN is established'

### DIFF
--- a/doc/mos_tests/neutron.rst
+++ b/doc/mos_tests/neutron.rst
@@ -11,3 +11,16 @@ Neutron DHCP Agent tests
 .. automodule:: mos_tests.neutron.python_tests.test_ban_dhcp_agent
    :members:
 
+Neutron L3 Agent tests
+----------------------
+.. automodule:: mos_tests.neutron.python_tests.test_l3_agent
+   :members:
+   
+Network specific tests
+======================
+
+VxLan tests
+-----------
+.. automodule:: mos_tests.neutron.python_tests.test_vxlan
+   :members:
+

--- a/mos_tests/environment/fuel_client.py
+++ b/mos_tests/environment/fuel_client.py
@@ -35,6 +35,7 @@ class Environment(EnvironmentBase):
         for node in self.get_all_nodes():
             if node.data['fqdn'] == fqdn:
                 return node
+        raise Exception("Node doesn't found")
 
     def get_ssh_to_node(self, ip):
         return SSHClient(

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -287,6 +287,11 @@ class OpenStackActions(object):
         logger.debug('Try to create key {0}'.format(key_name))
         return self.nova.keypairs.create(key_name)
 
+    @property
+    def ext_network(self):
+        exist_networks = self.list_networks()['networks']
+        return [x for x in exist_networks if x.get('router:external')][0]
+
     def delete_subnets(self, networks):
         # Subnets and ports are simply filtered by network ids
         for subnet in self.neutron.list_subnets()['subnets']:

--- a/mos_tests/neutron/README.md
+++ b/mos_tests/neutron/README.md
@@ -2,6 +2,10 @@
 
 Neutron python tests
 
+## System requirements
+
+`sudo apt-get install tshark`
+
 ## Running
 
 ### Arguments

--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -16,7 +16,7 @@ import six
 import pytest
 import logging
 
-from devops.helpers.helpers import wait
+from waiting import wait
 
 from mos_tests import settings
 
@@ -75,8 +75,7 @@ class TestBase(object):
                 vm_login=vm_login,
                 vm_ip=vm_ip,
                 command=command)
-            err_msg = ("SSH command:\n{command}\nwas not completed with "
-                       "exit code 0 after 3 attempts with 1 minute timeout.")
+            err_msg = ("SSH command:\n{command}\n completed with exit code 0.")
             results = []
 
             def run(cmd):
@@ -87,8 +86,8 @@ class TestBase(object):
                 cmd=cmd,
                 vm_name=vm.name))
             wait(lambda: run(cmd)['exit_code'] == 0,
-                 interval=60, timeout=timeout,
-                 timeout_msg=err_msg.format(command=cmd))
+                 sleep_seconds=(1, 60, 5), timeout_seconds=timeout,
+                 waiting_for=err_msg.format(command=cmd))
             return results[-1]
 
     def check_ping_from_vm(self, vm, vm_keypair, ip_to_ping=None,

--- a/mos_tests/neutron/python_tests/conftest.py
+++ b/mos_tests/neutron/python_tests/conftest.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import pytest
+from distutils.spawn import find_executable
 from devops.helpers.helpers import wait
 
 from mos_tests.environment.devops_client import DevopsClient
@@ -116,6 +117,15 @@ def setup(request, env_name, snapshot_name, env, os_conn):
 
 
 @pytest.fixture
+def tshark():
+    """Returns tshark bin path"""
+    path = find_executable('tshark')
+    if path is None:
+        pytest.skip('requires tshark executable')
+    return path
+
+
+@pytest.fixture
 def check_ha_env(env):
     """Check that deployment type is HA"""
     if not env.is_ha:
@@ -136,3 +146,10 @@ def check_devops(env_name):
         DevopsClient.get_env(env_name=env_name)
     except Exception:
         pytest.skip('requires devops env to be defined')
+
+
+@pytest.fixture
+def check_vxlan(env):
+    """Check that count of compute nodes not less than 2"""
+    if env.network_segmentation_type != 'tun':
+        pytest.skip('requires vxlan segmentation')

--- a/mos_tests/neutron/python_tests/test_l3_agent.py
+++ b/mos_tests/neutron/python_tests/test_l3_agent.py
@@ -16,7 +16,7 @@ import pytest
 import logging
 from neutronclient.common.exceptions import NeutronClientException
 
-from devops.helpers.helpers import wait
+from waiting import wait
 
 from mos_tests.environment.devops_client import DevopsClient
 from mos_tests.neutron.python_tests.base import TestBase
@@ -41,9 +41,6 @@ class TestL3Agent(TestBase):
             6. Ping 8.8.8.8, vm1 (both ip) and vm2 (fixed ip) from each other
         """
         # init variables
-        exist_networks = self.os_conn.list_networks()['networks']
-        ext_network = [x for x in exist_networks
-                       if x.get('router:external')][0]
         self.zone = self.os_conn.nova.availability_zones.find(zoneName="nova")
         self.security_group = self.os_conn.create_sec_group_for_ssh()
         self.hosts = self.zone.hosts.keys()[:2]
@@ -51,8 +48,9 @@ class TestL3Agent(TestBase):
 
         # create router
         router = self.os_conn.create_router(name="router01")
-        self.os_conn.router_gateway_add(router_id=router['router']['id'],
-                                        network_id=ext_network['id'])
+        self.os_conn.router_gateway_add(
+            router_id=router['router']['id'],
+            network_id=self.os_conn.ext_network['id'])
 
         # create 2 networks and 2 instances
         for i, hostname in enumerate(self.hosts, 1):
@@ -107,15 +105,17 @@ class TestL3Agent(TestBase):
             wait(
                 lambda: self.os_conn.get_l3_for_router(
                     router['id'])['agents'][0]['alive'] is False,
-                timeout=60 * 3, timeout_msg="L3 agent is alive"
+                timeout_seconds=60 * 3, waiting_for="L3 agent is die",
+                sleep_seconds=(1, 60)
             )
 
         # Wait to migrate l3 agent on new controller
         if wait_for_migrate:
-            err_msg = "l3 agent wasn't banned, it is still {0}"
+            waiting_for = "l3 agent migrate from {0}"
             wait(lambda: not node_with_l3 == self.os_conn.get_l3_agent_hosts(
-                 router['id'])[0], timeout=60 * 3,
-                 timeout_msg=err_msg.format(node_with_l3))
+                 router['id'])[0], timeout_seconds=60 * 3,
+                 waiting_for=waiting_for.format(node_with_l3),
+                 sleep_seconds=(1, 60))
         return node_with_l3
 
     def clear_l3_agent(self, _ip, router_name, node, wait_for_alive=False):
@@ -141,7 +141,8 @@ class TestL3Agent(TestBase):
             wait(
                 lambda: self.os_conn.get_l3_for_router(
                     router['id'])['agents'][0]['alive'] is True,
-                timeout=60 * 3, timeout_msg="L3 agent is dead yet"
+                timeout_seconds=60 * 3, waiting_for="L3 agent is alive",
+                sleep_seconds=(1, 60)
             )
 
     def drop_rabbit_port(self, router_name):
@@ -170,14 +171,16 @@ class TestL3Agent(TestBase):
         wait(
             lambda: self.os_conn.get_l3_for_router(
                 router['id'])['agents'][0]['alive'] is False,
-            timeout=60 * 3, timeout_msg="L3 agent is still alive"
+            timeout_seconds=60 * 3, waiting_for="L3 agent is died",
+            sleep_seconds=(1, 60)
         )
 
         # Wait to migrate l3 agent on new controller
-        err_msg = "l3 agent wasn't migrated, it is still on {0}"
+        waiting_for = "l3 agent migrated from {0}"
         wait(lambda: not node_with_l3 == self.os_conn.get_l3_agent_hosts(
-             router['id'])[0], timeout=60 * 3,
-             timeout_msg=err_msg.format(node_with_l3))
+             router['id'])[0], timeout_seconds=60 * 3,
+             waiting_for=waiting_for.format(node_with_l3),
+             sleep_seconds=(1, 60))
 
     @pytest.mark.parametrize('ban_count', [1, 2], ids=['single', 'twice'])
     def test_ban_one_l3_agent(self, ban_count):
@@ -332,10 +335,11 @@ class TestL3Agent(TestBase):
         # wait for router migrate to cleared node
         router = self.os_conn.neutron.list_routers(
             name='router01')['routers'][0]
-        err_msg = "l3 agent wasn't migrate to {0}"
+        waiting_for = "l3 agent wasn't migrate to {0}"
         wait(lambda: first_banned_node == self.os_conn.get_l3_agent_hosts(
-             router['id'])[0], timeout=60 * 3,
-             timeout_msg=err_msg.format(first_banned_node))
+             router['id'])[0], timeout_seconds=60 * 3,
+             waiting_for=waiting_for.format(first_banned_node),
+             sleep_seconds=(1, 60))
 
         # create another server on net01
         net01 = self.os_conn.nova.networks.find(label="net01")
@@ -485,21 +489,19 @@ class TestL3Agent(TestBase):
             raise Exception("Can't find devops controller node to destroy it")
 
         # Wait for l3 agent die
-        def is_l3_die():
-            try:
-                return self.os_conn.get_l3_for_router(
-                    router['id'])['agents'][0]['alive'] is False
-            except NeutronClientException:
-                return False
+        wait(
+            lambda: self.os_conn.get_l3_for_router(
+                router['id'])['agents'][0]['alive'] is False,
+            expected_exceptions=NeutronClientException,
+            timeout_seconds=60 * 5, sleep_seconds=(1, 60, 5),
+            waiting_for="L3 agent is died")
 
-        wait(is_l3_die, timeout=60 * 5, timeout_msg="L3 agent is alive")
-
-        # Wait for migrate all router from died L3 agent
+        # Wait for migrating all routers from died L3 agent
         wait(
             lambda: len(self.os_conn.neutron.list_routers_on_l3_agent(
                 l3_agent['id'])['routers']) == 0,
-            timeout=60 * 5,
-            timeout_msg = "Routers are not resheduled from L3 agent"
+            timeout_seconds=60 * 5, sleep_seconds=(1, 60, 5),
+            waiting_for="migrating all routers from died L3 agent"
         )
 
         # create another server on net01

--- a/mos_tests/neutron/python_tests/test_vxlan.py
+++ b/mos_tests/neutron/python_tests/test_vxlan.py
@@ -1,0 +1,124 @@
+#    Copyright 2015 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import pytest
+import subprocess
+import threading
+import logging
+
+from mos_tests.neutron.python_tests.base import TestBase
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.usefixtures("check_ha_env", "check_vxlan", "setup")
+class TestVxlan(TestBase):
+    """ Vxlan (tun) specific tests"""
+
+    def test_tunnel_established(self, tshark):
+        """Check that VxLAN is established on nodes and VNI matching
+           the segmentation_id of a network
+
+        Scenario:
+            1. Create private network net01, subnet 10.1.1.0/24
+            2. Create router01, add interface for net01 and set gateway to
+                external network
+            3. Boot instance vm1_1 in net01
+            4. Look on what node l3 agent for this router01 is
+            5. Check that tunnel is established on controller
+            6. Check that tunnel is established on compute
+            7. On node with l3 agent find namespace qrouter
+            8. Add rules for ping and ssh connection
+            9. Go to the compute with vm_1 and run
+                tcpdump -vvni any port 4789 -w vxlan.log
+            10. Ping from qrouter namespace vm1
+            11. Copy vxlan.log for your computer and open it with Wireshark.
+                Press right button, choose Decode as, Transport
+                and choose VXLAN
+        """
+        # Init variables
+        self.zone = self.os_conn.nova.availability_zones.find(zoneName="nova")
+        self.security_group = self.os_conn.create_sec_group_for_ssh()
+        compute_node = self.zone.hosts.keys()[0]
+        self.instance_keypair = self.os_conn.create_key(key_name='instancekey')
+
+        # Create router
+        router = self.os_conn.create_router(name="router01")
+        self.os_conn.router_gateway_add(
+            router_id=router['router']['id'],
+            network_id=self.os_conn.ext_network['id'])
+
+        # Create network and instance
+        network = self.os_conn.create_network(name='net01')
+        subnet = self.os_conn.create_subnet(
+            network_id=network['network']['id'],
+            name='net01__subnet',
+            cidr="10.1.1.0/24")
+        self.os_conn.router_interface_add(
+            router_id=router['router']['id'],
+            subnet_id=subnet['subnet']['id'])
+        server = self.os_conn.create_server(
+            name='server01',
+            availability_zone='{}:{}'.format(self.zone.zoneName, compute_node),
+            key_name=self.instance_keypair.name,
+            nics=[{'net-id': network['network']['id']}],
+            security_groups=[self.security_group.id])
+
+        router_node = self.os_conn.get_l3_agent_hosts(
+            router['router']['id'])[0]
+        controller = self.env.find_node_by_fqdn(router_node)
+        compute = self.env.find_node_by_fqdn(compute_node)
+
+        # Check controller and compute
+        for node in (controller, compute):
+            with self.env.get_ssh_to_node(node.data['ip']) as remote:
+                result = remote.execute('ovs-vsctl show | grep -q br-tun')
+                assert result['exit_code'] == 0
+
+        def tcpdump():
+            ip = compute.data['ip']
+            logger.info('Start tcpdump')
+            with self.env.get_ssh_to_node(ip) as remote:
+                result = remote.execute(
+                    'tcpdump -U -vvni any port 4789 -w /tmp/vxlan.log')
+                assert result['exit_code'] == 0
+
+        # Start tcpdump
+        thread = threading.Thread(target=tcpdump)
+
+        try:
+            thread.start()
+            # Ping server01
+            with self.env.get_ssh_to_node(controller.data['ip']) as remote:
+                vm_ip = self.os_conn.get_nova_instance_ips(server)['fixed']
+                result = remote.execute(
+                    'ip netns exec qrouter-{router_id} ping -c1 {ip}'.format(
+                        router_id=router['router']['id'],
+                        ip=vm_ip))
+        finally:
+            ip = compute.data['ip']
+            with self.env.get_ssh_to_node(ip) as remote:
+                remote.execute('killall tcpdump')
+            thread.join(0)
+
+        # Download log
+        with self.env.get_ssh_to_node(compute.data['ip']) as remote:
+            remote.download('/tmp/vxlan.log', '/tmp/vxlan.log')
+
+        # Check log
+        vni = network['network']['provider:segmentation_id']
+        output = subprocess.check_output([tshark, '-d', 'udp.port==4789,vxlan',
+                                          '-r', '/tmp/vxlan.log', '-Y',
+                                          'vxlan.vni!={0}'.format(vni)])
+        assert not output.strip(), 'Log contains records with another VNI'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 git+git://github.com/openstack/fuel-devops.git@2.9.13
 pytest
 pytest-xdist
+waiting
 python-glanceclient==0.17.1
 python-keystoneclient>=2.0.0
 python-novaclient>=2.15.0


### PR DESCRIPTION
Testcase checks that VxLAN is established on nodes and VNI matching
the segmentation_id of a network

Scenario:
1. Create private network net01, subnet 10.1.1.0/24
2. Create router01, add interface for net01 and set gateway to
    external network
3. Boot instance vm1_1 in net01
4. Look on what node l3 agent for this router01 is
5. Check that tunnel is established on controller
6. Check that tunnel is established on compute
7. On node with l3 agent find namespace qrouter
8. Add rules for ping and ssh connection
9. Go to the compute with vm_1 and run
    tcpdump -vvni any port 4789 -w vxlan.log
10. Ping from qrouter namespace vm1
11. Copy vxlan.log for your computer and open it with Wireshark.
    Press right button, choose Decode as, Transport
    and choose VXLAN
