### PR TITLE
Add testcase 'Check broadcast traffic for l2pop'

### DIFF
--- a/mos_tests/environment/devops_client.py
+++ b/mos_tests/environment/devops_client.py
@@ -90,7 +90,9 @@ class DevopsClient(object):
     def sync_tyme(cls, env):
         with env.get_admin_remote() as remote:
             slaves_count = len(env.nodes().all) - 1
+            logger.info("sync time on master")
             remote.execute('hwclock --hctosys')
+            logger.info("sync time on {} slaves".format(slaves_count))
             remote.execute('for i in {{1..{0}}}; do ssh node-$i '
                            '"hwclock --hctosys"; done'.format(slaves_count))
 

--- a/mos_tests/environment/fuel_client.py
+++ b/mos_tests/environment/fuel_client.py
@@ -139,6 +139,7 @@ class Environment(EnvironmentBase):
 class FuelClient(object):
     """Fuel API client"""
     def __init__(self, ip, login, password, ssh_login, ssh_password):
+        logger.info('Init fuel client on {0}'.format(ip))
         self.reconfigure_fuelclient(ip, login, password)
         self.admin_ip = ip
         self.ssh_login = ssh_login

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -259,9 +259,10 @@ class OpenStackActions(object):
                     body={'floatingip': {}})
 
                 id = floating_ip['id']
-                helpers.wait(
+                wait(
                     lambda: self.neutron.show_floatingip(id)
-                            ['floatingip']['status'] == "DOWN", timeout=60)
+                            ['floatingip']['status'] == "DOWN",
+                    timeout_seconds=60)
             except NeutronClientException:
                 logger.info('The floatingip {} can not be disassociated.'
                             .format(floating_ip['id']))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/openstack/fuel-devops.git@2.9.14
+git+git://github.com/openstack/fuel-devops.git@2.9.15
 paramiko>=1.16.0
 pytest
 pytest-xdist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/openstack/fuel-devops.git@2.9.13
+git+git://github.com/openstack/fuel-devops.git@2.9.14
 paramiko>=1.16.0
 pytest
 pytest-xdist


### PR DESCRIPTION
```
Testcase checks broadcast traffic propagation for network segments with
l2pop driver enabled

Scenario:
1. Create private network net01, subnet 10.1.1.0/24
2. Create private network net02, subnet 10.1.2.0/24
3. Create router01_02 and connect net01 and net02 with it
4. Boot instances vm1 in net01 and vm2 in net02
    on different computes
5. Check that net02 got a new segmentation_id, different from net1
6. Go to the vm1's console and initiate broadcast traffic to vm2
7. On the compute where vm2 is hosted start listen vxlan port 4789
8. Check that no ARP traffic associated with vm1-vm2 pair
    appears on compute node's console
9. Go to the vm1's console, stop arping and initiate
    unicast traffic to vm2
10. Check that ICMP unicast traffic associated with vm1-vm2 pair
    was captured on compute node's console
```
