### PR TITLE
Resolve conflict with pytest-django from devops

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:django


### PR DESCRIPTION
Pytest-django installed with fuel-devops. This patch disabled it, because we don't to test fuel-devops database models, only use those.
