### PR TITLE
Add testcase 'Check the tunnels established l2pop'

### DIFF
--- a/mos_tests/environment/fuel_client.py
+++ b/mos_tests/environment/fuel_client.py
@@ -139,7 +139,7 @@ class Environment(EnvironmentBase):
 class FuelClient(object):
     """Fuel API client"""
     def __init__(self, ip, login, password, ssh_login, ssh_password):
-        logger.info('Init fuel client on {0}'.format(ip))
+        logger.debug('Init fuel client on {0}'.format(ip))
         self.reconfigure_fuelclient(ip, login, password)
         self.admin_ip = ip
         self.ssh_login = ssh_login

--- a/mos_tests/environment/fuel_client.py
+++ b/mos_tests/environment/fuel_client.py
@@ -14,13 +14,15 @@
 
 import logging
 import os
-from paramiko import RSAKey
 
 from devops.helpers.helpers import wait
+from fuelclient import client
 from fuelclient import fuelclient_settings
 from fuelclient.objects.environment import Environment as EnvironmentBase
-from fuelclient import client
+from paramiko import RSAKey
+
 from mos_tests.environment.ssh import SSHClient
+
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +58,7 @@ class Environment(EnvironmentBase):
 
     def get_all_nodes(self):
         nodes = super(Environment, self).get_all_nodes()
-        nodes[:] = [NodeProxy(x, self) for x in nodes]
-        return nodes
+        return [NodeProxy(x, self) for x in nodes]
 
     def get_primary_controller_ip(self):
         """Return public ip of primary controller"""

--- a/mos_tests/environment/fuel_client.py
+++ b/mos_tests/environment/fuel_client.py
@@ -25,10 +25,39 @@ from mos_tests.environment.ssh import SSHClient
 logger = logging.getLogger(__name__)
 
 
+class NodeProxy(object):
+    """Fuelclient Node proxy model with some helpful methods"""
+
+    def __init__(self, orig_node, env):
+        self._orig_node = orig_node
+        self._env = env
+
+    def __getattr__(self, name):
+        return getattr(self._orig_node, name)
+
+    @property
+    def ip_list(self):
+        """Returns node ip addresses list"""
+        return [x['ip'].split('/')[0] for x in self.data['network_data']
+                if 'ip' in x]
+
+    def ssh(self):
+        return SSHClient(
+            host=self.data['ip'],
+            username='root',
+            private_keys=self._env.admin_ssh_keys
+        )
+
+
 class Environment(EnvironmentBase):
     """Extended fuelclient Environment model with some helpful methods"""
 
     admin_ssh_keys = None
+
+    def get_all_nodes(self):
+        nodes = super(Environment, self).get_all_nodes()
+        nodes[:] = [NodeProxy(x, self) for x in nodes]
+        return nodes
 
     def get_primary_controller_ip(self):
         """Return public ip of primary controller"""

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -13,20 +13,20 @@
 #    under the License.
 
 import logging
-import time
 import random
 from tempfile import NamedTemporaryFile
-from waiting import wait
+import time
 
 from cinderclient import client as cinderclient
 from glanceclient.v1 import Client as GlanceClient
-from keystoneclient.v2_0 import Client as KeystoneClient
 from keystoneclient.exceptions import ClientException as KeyStoneException
+from keystoneclient.v2_0 import Client as KeystoneClient
+from neutronclient.common.exceptions import NeutronClientException
+import neutronclient.v2_0.client as neutronclient
 from novaclient import client as nova_client
 from novaclient.exceptions import ClientException as NovaClientException
-import neutronclient.v2_0.client as neutronclient
-from neutronclient.common.exceptions import NeutronClientException
 import paramiko
+from waiting import wait
 
 logger = logging.getLogger(__name__)
 

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -13,9 +13,9 @@
 #    under the License.
 
 import logging
+import time
 import random
 from tempfile import NamedTemporaryFile
-import time
 from waiting import wait
 
 from cinderclient import client as cinderclient

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -35,7 +35,7 @@ class OpenStackActions(object):
 
     def __init__(self, controller_ip, user='admin', password='admin',
                  tenant='admin', cert=None):
-        logger.info('Init OpenStack clients on {0}'.format(controller_ip))
+        logger.debug('Init OpenStack clients on {0}'.format(controller_ip))
         self.controller_ip = controller_ip
 
         if cert is None:
@@ -151,7 +151,7 @@ class OpenStackActions(object):
             timeout_seconds=timeout, sleep_seconds=5,
             waiting_for='instance {0} status change to ACTIVE'.format(
                 name))
-        logger.info('the server {0} is "ACTIVE"'.format(srv.name))
+        logger.info('the server {0} is ready'.format(srv.name))
         return self.get_instance_detail(srv.id)
 
     def get_nova_instance_ips(self, srv):

--- a/mos_tests/neutron/conftest.py
+++ b/mos_tests/neutron/conftest.py
@@ -12,6 +12,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from distutils.spawn import find_executable
+import pytest
+
+from mos_tests.environment.devops_client import DevopsClient
+from mos_tests.settings import SERVER_ADDRESS
+
 
 def pytest_addoption(parser):
     parser.addoption("--fuel-ip", '-I', action="store",
@@ -20,3 +26,112 @@ def pytest_addoption(parser):
                      help="Fuel devops env name")
     parser.addoption("--snapshot", '-S', action="store",
                      help="Fuel devops snapshot name")
+
+
+def pytest_configure(config):
+    # register an additional marker
+    config.addinivalue_line("markers",
+        "check_env_(check1, check2): mark test to run only on env, which pass "
+        "all checks")
+    config.addinivalue_line("markers",
+        "need_devops: mark test wich need devops to run")
+    config.addinivalue_line("markers",
+        "neeed_tshark: mark test wich need tshark to be installed to run")
+
+
+def pytest_runtest_makereport(item, call):
+    if call.excinfo is not None and call.excinfo.typename == 'Skipped':
+        setattr(item, 'env_destroyed', False)
+
+
+def pytest_runtest_teardown(item, nextitem):
+    if not getattr(item, 'env_destroyed', True) and nextitem is not None:
+        setattr(nextitem, 'do_revert', False)
+
+
+@pytest.fixture
+def env_name(request):
+    return request.config.getoption("--env")
+
+
+@pytest.fixture
+def snapshot_name(request):
+    return request.config.getoption("--snapshot")
+
+
+@pytest.fixture
+def revert_snapshot(request, env_name, snapshot_name):
+    """Revert Fuel devops snapshot before test"""
+    if getattr(request.node, 'do_revert', True):
+        DevopsClient.revert_snapshot(env_name=env_name,
+                                     snapshot_name=snapshot_name)
+
+
+@pytest.fixture
+def fuel_master_ip(request, env_name, snapshot_name):
+    """Get fuel master ip"""
+    fuel_ip = request.config.getoption("--fuel-ip")
+    if not fuel_ip:
+        fuel_ip = DevopsClient.get_admin_node_ip(env_name=env_name)
+        revert_snapshot(request, env_name, snapshot_name)
+        setattr(request.node, 'do_revert', False)
+    if not fuel_ip:
+        fuel_ip = SERVER_ADDRESS
+    return fuel_ip
+
+
+def is_ha(env):
+    """Env deployed with HA (3 controllers)"""
+    return env.is_ha and len(env.get_nodes_by_role('controller')) >= 3
+
+
+def has_2_or_more_computes(env):
+    """Env deployed with 2 or more computes"""
+    return len(env.get_nodes_by_role('compute')) >= 2
+
+
+def has_3_or_more_computes(env):
+    """Env deployed with 3 or more computes"""
+    return len(env.get_nodes_by_role('compute')) >= 3
+
+
+def is_vxlan(env):
+    """Env deployed with vxlan segmentation"""
+    return env.network_segmentation_type == 'tun'
+
+
+def is_l2pop(env):
+    """Env deployed with vxlan segmentation and l2 population"""
+    cmd = 'grep -q ^l2_population=True /etc/neutron/plugin.ini'
+    controller = env.get_nodes_by_role('controller')[0]
+    with env.get_ssh_to_node(controller.data['ip']) as remote:
+        result = remote.execute(cmd)
+    return is_vxlan(env) and result['exit_code'] == 0
+
+
+@pytest.fixture(autouse=True)
+def env_requirements(request, env):
+    if request.node.get_marker('check_env_'):
+        for func_name in request.node.get_marker('check_env_').args:
+            func = globals().get(func_name)
+            if func is not None and not func(env):
+                doc = func.__doc__ or 'Env {}'.format(
+                    func_name.replace('_', ' '))
+                pytest.skip('Requires: {}'.format(doc))
+
+
+@pytest.fixture(autouse=True)
+def devops_requirements(request, env_name):
+    if request.node.get_marker('need_devops'):
+        try:
+            DevopsClient.get_env(env_name=env_name)
+        except Exception:
+            pytest.skip('requires devops env to be defined')
+
+
+@pytest.fixture(autouse=True)
+def tshark_requirements(request, env_name):
+    if request.node.get_marker('need_tshark'):
+        path = find_executable('tshark')
+        if path is None:
+            pytest.skip('requires tshark executable')

--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -22,6 +22,7 @@ from waiting import wait
 
 from mos_tests import settings
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -122,7 +122,7 @@ class TestBase(object):
                 results.append(remote.execute(cmd))
                 return results[-1]
 
-            logger.info('Executing {cmd} on {vm_name}'.format(
+            logger.info('Executing {command} on {vm_name}'.format(
                 cmd=cmd,
                 vm_name=vm.name))
             wait(lambda: run(cmd)['exit_code'] == 0,

--- a/mos_tests/neutron/python_tests/conftest.py
+++ b/mos_tests/neutron/python_tests/conftest.py
@@ -13,15 +13,17 @@
 #    under the License.
 
 import logging
+
 import pytest
 from waiting import wait
 
 from mos_tests.environment.fuel_client import FuelClient
 from mos_tests.environment.os_actions import OpenStackActions
-from mos_tests.settings import KEYSTONE_USER
-from mos_tests.settings import KEYSTONE_PASS
-from mos_tests.settings import SSH_CREDENTIALS
 from mos_tests.neutron.conftest import revert_snapshot
+from mos_tests.settings import KEYSTONE_PASS
+from mos_tests.settings import KEYSTONE_USER
+from mos_tests.settings import SSH_CREDENTIALS
+
 
 logger = logging.getLogger(__name__)
 

--- a/mos_tests/neutron/python_tests/conftest.py
+++ b/mos_tests/neutron/python_tests/conftest.py
@@ -14,59 +14,16 @@
 
 import logging
 import pytest
-from distutils.spawn import find_executable
 from waiting import wait
 
-from mos_tests.environment.devops_client import DevopsClient
 from mos_tests.environment.fuel_client import FuelClient
 from mos_tests.environment.os_actions import OpenStackActions
-from mos_tests.settings import SERVER_ADDRESS
 from mos_tests.settings import KEYSTONE_USER
 from mos_tests.settings import KEYSTONE_PASS
 from mos_tests.settings import SSH_CREDENTIALS
+from mos_tests.neutron.conftest import revert_snapshot
 
 logger = logging.getLogger(__name__)
-
-
-def pytest_runtest_makereport(item, call):
-    if call.excinfo is not None and call.excinfo.typename == 'Skipped':
-        setattr(item, 'env_destroyed', False)
-
-
-def pytest_runtest_teardown(item, nextitem):
-    if getattr(item, 'destroyed', True) and nextitem is not None:
-        setattr(nextitem, 'do_revert', True)
-
-
-@pytest.fixture
-def env_name(request):
-    return request.config.getoption("--env")
-
-
-@pytest.fixture
-def snapshot_name(request):
-    return request.config.getoption("--snapshot")
-
-
-@pytest.fixture
-def revert_snapshot(request, env_name, snapshot_name):
-    """Revert Fuel devops snapshot before test"""
-    if getattr(request.node, 'do_revert', True):
-        DevopsClient.revert_snapshot(env_name=env_name,
-                                     snapshot_name=snapshot_name)
-
-
-@pytest.fixture
-def fuel_master_ip(request, env_name, snapshot_name):
-    """Get fuel master ip"""
-    fuel_ip = request.config.getoption("--fuel-ip")
-    if not fuel_ip:
-        fuel_ip = DevopsClient.get_admin_node_ip(env_name=env_name)
-        revert_snapshot(request, env_name, snapshot_name)
-        setattr(request.node, 'do_revert', False)
-    if not fuel_ip:
-        fuel_ip = SERVER_ADDRESS
-    return fuel_ip
 
 
 @pytest.fixture
@@ -130,53 +87,3 @@ def setup(request, env_name, snapshot_name, env, os_conn):
     if not env_name:
         clear_l3_ban(env, os_conn)
         clean_os(os_conn)
-
-
-@pytest.fixture
-def tshark():
-    """Returns tshark bin path"""
-    path = find_executable('tshark')
-    if path is None:
-        pytest.skip('requires tshark executable')
-    return path
-
-
-@pytest.fixture
-def check_ha_env(env):
-    """Check that deployment type is HA"""
-    if not env.is_ha or len(env.get_nodes_by_role('controller')) < 3:
-        pytest.skip('requires HA cluster')
-
-
-@pytest.fixture
-def check_several_computes(env):
-    """Check that count of compute nodes not less than 2"""
-    if len(env.get_nodes_by_role('compute')) < 2:
-        pytest.skip('requires at least 2 compute node')
-
-
-@pytest.fixture
-def check_devops(env_name):
-    """Check that devops env is defined"""
-    try:
-        DevopsClient.get_env(env_name=env_name)
-    except Exception:
-        pytest.skip('requires devops env to be defined')
-
-
-@pytest.fixture
-def check_vxlan(env):
-    """Check that env has vxlan network segmentation"""
-    if env.network_segmentation_type != 'tun':
-        pytest.skip('requires vxlan segmentation')
-
-
-@pytest.fixture
-def check_l2pop(env, check_vxlan):
-    """Check that env has vxlan segmentation woth l2 population"""
-    cmd = 'grep -q ^l2_population=True /etc/neutron/plugin.ini'
-    controller = env.get_nodes_by_role('controller')[0]
-    with env.get_ssh_to_node(controller.data['ip']) as remote:
-        result = remote.execute(cmd)
-    if result['exit_code'] != 0:
-        pytest.skip('requires vxlan with l2 population')

--- a/mos_tests/neutron/python_tests/test_ban_dhcp_agent.py
+++ b/mos_tests/neutron/python_tests/test_ban_dhcp_agent.py
@@ -24,7 +24,8 @@ from mos_tests import settings
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("check_ha_env", "check_several_computes", "setup")
+@pytest.mark.check_env_('is_ha', 'has_2_or_more_computes')
+@pytest.mark.usefixtures("setup")
 class TestBanDHCPAgent(base.TestBase):
     """Check DHCP agents rescheduling."""
 

--- a/mos_tests/neutron/python_tests/test_dhcp_agent.py
+++ b/mos_tests/neutron/python_tests/test_dhcp_agent.py
@@ -21,7 +21,8 @@ from mos_tests.neutron.python_tests.base import TestBase
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("check_ha_env", "check_several_computes", "setup")
+@pytest.mark.check_env_('is_ha', 'has_2_or_more_computes')
+@pytest.mark.usefixtures("setup")
 class TestDHCPAgent(TestBase):
 
     @pytest.fixture(autouse=True)

--- a/mos_tests/neutron/python_tests/test_dhcp_agent.py
+++ b/mos_tests/neutron/python_tests/test_dhcp_agent.py
@@ -12,11 +12,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import pytest
-
 import logging
 
+import pytest
+
 from mos_tests.neutron.python_tests.base import TestBase
+
 
 logger = logging.getLogger(__name__)
 

--- a/mos_tests/neutron/python_tests/test_floating_ip.py
+++ b/mos_tests/neutron/python_tests/test_floating_ip.py
@@ -12,9 +12,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from paramiko.ssh_exception import NoValidConnectionsError
+from paramiko.ssh_exception import SSHException
 import pytest
-
-from paramiko.ssh_exception import SSHException, NoValidConnectionsError
 
 from mos_tests.neutron.python_tests.base import TestBase
 

--- a/mos_tests/neutron/python_tests/test_l3_agent.py
+++ b/mos_tests/neutron/python_tests/test_l3_agent.py
@@ -21,6 +21,7 @@ from waiting import wait
 from mos_tests.environment.devops_client import DevopsClient
 from mos_tests.neutron.python_tests.base import TestBase
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/mos_tests/neutron/python_tests/test_l3_agent.py
+++ b/mos_tests/neutron/python_tests/test_l3_agent.py
@@ -24,7 +24,8 @@ from mos_tests.neutron.python_tests.base import TestBase
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("check_ha_env", "check_several_computes", "setup")
+@pytest.mark.check_env_('is_ha', 'has_2_or_more_computes')
+@pytest.mark.usefixtures("setup")
 class TestL3Agent(TestBase):
 
     @pytest.fixture(autouse=True)
@@ -183,7 +184,7 @@ class TestL3Agent(TestBase):
              waiting_for=waiting_for.format(node_with_l3),
              sleep_seconds=(1, 60))
 
-    @pytest.mark.parametrize('ban_count', [1, 2], ids=['single', 'twice'])
+    @pytest.mark.parametrize('ban_count', [1, 2], ids=['once', 'twice'])
     def test_ban_one_l3_agent(self, ban_count):
         """Check l3-agent rescheduling after l3-agent dies on vlan
 
@@ -436,7 +437,8 @@ class TestL3Agent(TestBase):
         # check pings
         self.check_vm_connectivity()
 
-    def test_shutdown_not_primary_controller(self, check_devops, env_name):
+    @pytest.mark.need_devops
+    def test_shutdown_not_primary_controller(self, env_name):
         """Shut down non-primary controller and check l3-agent work
 
         Scenario:

--- a/mos_tests/neutron/python_tests/test_restarts.py
+++ b/mos_tests/neutron/python_tests/test_restarts.py
@@ -22,7 +22,8 @@ from mos_tests.environment.devops_client import DevopsClient
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("check_ha_env", "check_several_computes", "setup")
+@pytest.mark.check_env_('is_ha', 'has_2_or_more_computes')
+@pytest.mark.usefixtures("setup")
 class TestRestarts(TestBase):
 
     @pytest.fixture(autouse=True)

--- a/mos_tests/neutron/python_tests/test_restarts.py
+++ b/mos_tests/neutron/python_tests/test_restarts.py
@@ -12,12 +12,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import pytest
-
 import logging
 
-from mos_tests.neutron.python_tests.base import TestBase
+import pytest
+
 from mos_tests.environment.devops_client import DevopsClient
+from mos_tests.neutron.python_tests.base import TestBase
+
 
 logger = logging.getLogger(__name__)
 

--- a/mos_tests/neutron/python_tests/test_vxlan.py
+++ b/mos_tests/neutron/python_tests/test_vxlan.py
@@ -15,11 +15,13 @@
 from contextlib import contextmanager
 from distutils.spawn import find_executable
 import logging
-import pytest
 import subprocess
 import threading
 
+import pytest
+
 from mos_tests.neutron.python_tests.base import TestBase
+
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +44,7 @@ def tcpdump_vxlan(ip, env, log_path):
         # Start tcpdump
         thread.start()
         yield
-    except:
+    except Exception:
         raise
     else:
         # Download log

--- a/mos_tests/neutron/python_tests/test_vxlan.py
+++ b/mos_tests/neutron/python_tests/test_vxlan.py
@@ -336,3 +336,129 @@ class TestVxlanL2pop(TestVxlanBase):
 
         check_icmp_traffic(src_ip=server1_ip, dst_ip=server2_ip,
                            log_file=unicast_log)
+
+    @pytest.mark.check_env_('has_3_or_more_computes')
+    def test_establishing_tunnels_between_computes(self, variables):
+        """Check the tunnels established between computes
+
+        Scenario:
+            1. Create net01, net01__subnet, 192.168.1.0/24
+            2. Launch vm1 in net01 network on compute1
+            3. Go to compute1's console and check that only tunnels
+                to controllers appear and no tunnels are to compute2
+                and compute3
+            4. Go to compute2 and compute3 consoles and check that
+                no tunnels appear on them
+            5. Launch vm2 in net01 network on compute2
+            6. Go to compute2's console and check that tunnels
+                to controllers and compute1 appear
+            7. Go to compute1's console and check that tunnel
+                to compute2 is added
+            8. Go to compute3's console and check that no tunnels appear on it
+            9. Launch vm3 in net01 network on compute3
+            10. Go to compute3's console and check that tunnels to controllers,
+                compute1 and compute2 appear
+            11. Go to compute1 and compute2 consoles and check that tunnels
+                to compute3 are added on them
+        """
+        # Create net, subnet and server01
+        compute_nodes = self.zone.hosts.keys()[:3]
+
+        network = self.os_conn.create_network(name='net01')
+        self.os_conn.create_subnet(
+            network_id=network['network']['id'],
+            name='net01__subnet',
+            cidr="192.168.1.0/24")
+        self.os_conn.create_server(
+            name='server01',
+            availability_zone='{}:{}'.format(self.zone.zoneName,
+                                             compute_nodes[0]),
+            key_name=self.instance_keypair.name,
+            nics=[{'net-id': network['network']['id']}],
+            security_groups=[self.security_group.id])
+
+        compute1 = self.env.find_node_by_fqdn(compute_nodes[0])
+        compute2 = self.env.find_node_by_fqdn(compute_nodes[1])
+        compute3 = self.env.find_node_by_fqdn(compute_nodes[2])
+        controllers = self.env.get_nodes_by_role('controller')
+        # Check that compute1 tunnels only to controller
+        with compute1.ssh() as remote:
+            result = remote.execute(
+                'ovs-vsctl show')
+            assert result['exit_code'] == 0
+            stdout = ''.join(result['stdout'])
+            assert any([x in stdout for c in controllers for x in c.ip_list])
+            assert not any([x in stdout for x in compute2.ip_list])
+            assert not any([x in stdout for x in compute3.ip_list])
+
+        # Check that compute2 and compute3 have not tunnels
+        for node in (compute2, compute3):
+            with node.ssh() as remote:
+                result = remote.execute(
+                    'ovs-vsctl show')
+                assert result['exit_code'] == 0
+                stdout = ''.join(result['stdout'])
+                assert not any([x in stdout for x
+                               in ('local_ip', 'remote_ip')])
+
+        # Create server02
+        self.os_conn.create_server(
+            name='server02',
+            availability_zone='{}:{}'.format(self.zone.zoneName,
+                                             compute_nodes[1]),
+            key_name=self.instance_keypair.name,
+            nics=[{'net-id': network['network']['id']}],
+            security_groups=[self.security_group.id])
+
+        # Check that compute2 have tunnels to controller abd compute1
+        with compute2.ssh() as remote:
+            result = remote.execute(
+                'ovs-vsctl show')
+            assert result['exit_code'] == 0
+            stdout = ''.join(result['stdout'])
+            assert any([x in stdout for c in controllers for x in c.ip_list])
+            assert any([x in stdout for x in compute1.ip_list])
+
+        # Check that compute1 have tunnel to compute2
+        with compute2.ssh() as remote:
+            result = remote.execute(
+                'ovs-vsctl show')
+            assert result['exit_code'] == 0
+            stdout = ''.join(result['stdout'])
+            assert any([x in stdout for x in compute2.ip_list])
+
+        # Check that compute3 haven't tunnels
+        with compute3.ssh() as remote:
+            result = remote.execute(
+                'ovs-vsctl show')
+            assert result['exit_code'] == 0
+            stdout = ''.join(result['stdout'])
+            assert not any([x in stdout for x in ('local_ip', 'remote_ip')])
+
+        # Create server03
+        self.os_conn.create_server(
+            name='server03',
+            availability_zone='{}:{}'.format(self.zone.zoneName,
+                                             compute_nodes[2]),
+            key_name=self.instance_keypair.name,
+            nics=[{'net-id': network['network']['id']}],
+            security_groups=[self.security_group.id])
+
+        # Check that compute3 have tunnels to controller, compute1 and compute2
+        with compute3.ssh() as remote:
+            result = remote.execute(
+                'ovs-vsctl show')
+            assert result['exit_code'] == 0
+            stdout = ''.join(result['stdout'])
+            assert any([x in stdout for c in controllers for x in c.ip_list])
+            assert any([x in stdout for x in compute2.ip_list])
+            assert any([x in stdout for x in compute3.ip_list])
+
+        # Check compute2 and compute3 have tunnels to compute3
+        for node in (compute1, compute2):
+            with node.ssh() as remote:
+                result = remote.execute(
+                    'ovs-vsctl show')
+                assert result['exit_code'] == 0
+                stdout = ''.join(result['stdout'])
+                assert any([x in stdout for x in compute3.ip_list])


### PR DESCRIPTION
Testcase checks that the tunnels established between computes with l2pop
enabled.

Scenario:
1. Create net01, net01__subnet, 192.168.1.0/24
2. Launch vm1 in net01 network on compute1
3. Go to compute1's console and check that only tunnels
    to controllers appear and no tunnels are to compute2
    and compute3
4. Go to compute2 and compute3 consoles and check that
    no tunnels appear on them
5. Launch vm2 in net01 network on compute2
6. Go to compute2's console and check that tunnels
    to controllers and compute1 appear
7. Go to compute1's console and check that tunnel
    to compute2 is added
8. Go to compute3's console and check that no tunnels appear on it
9. Launch vm3 in net01 network on compute3
10. Go to compute3's console and check that tunnels to controllers,
    compute1 and compute2 appear
11. Go to compute1 and compute2 consoles and check that tunnels
    to compute3 are added on them
