### PR TITLE
Add testcase 'Broadcast traffic between instances'

### DIFF
--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -123,7 +123,7 @@ class TestBase(object):
                 results.append(remote.execute(cmd))
                 return results[-1]
 
-            logger.info('Executing {cmd} on {vm_name}'.format(
+            logger.info('Executing `{cmd}` on {vm_name}'.format(
                 cmd=command,
                 vm_name=vm.name))
             wait(lambda: run(cmd)['exit_code'] == 0,


### PR DESCRIPTION
Testcase checks broadcast traffic between instances placed in different
private networks and hosted on different nodes

Scenario:
1. Create private network net01, subnet 10.1.1.0/24
2. Create private network net02, subnet 10.1.2.0/24
3. Create router01_02 and connect net01 and net02 with it
4. Boot instances vm1 in net01 and vm2 in net02
    on different computes
5. Check that net02 got a new segmentation_id, different from net1
6. Go to the vm1's console and initiate broadcast traffic to vm2
7. On the compute where vm2 is hosted start listen vxlan port 4789
8. Check that no ARP traffic associated with vm1-vm2 pair
    appears on compute node's console
9. Go to the vm1's console, stop arping and initiate
    unicast traffic to vm2
10. Check that ICMP unicast traffic associated with vm1-vm2 pair
    was captured on compute node's console
