### PR TITLE
Add testcase 'Broadcast traffic between instances'

### DIFF
--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -336,6 +336,13 @@ class OpenStackActions(object):
         logger.debug('Try to create key {0}'.format(key_name))
         return self.nova.keypairs.create(key_name)
 
+    def get_port_by_fixed_ip(self, ip):
+        """Returns neutron port by instance fixed ip"""
+        for port in self.neutron.list_ports()['ports']:
+            for ips in port['fixed_ips']:
+                if ip == ips['ip_address']:
+                    return port
+
     @property
     def ext_network(self):
         exist_networks = self.list_networks()['networks']


### PR DESCRIPTION
Testcase checks broadcast traffic between instances placed in a single
private network and hosted on different nodes

Scenario:
1. Create private network net01, subnet 10.1.1.0/24
2. Create private network net02, subnet 10.1.2.0/24
3. Create router01_02 and connect net01 and net02 with it
4. Boot instances vm1 in net01 and compute1
5. Boot instances vm2 in net01 and compute2
6. Boot instances vm3 in net02 and compute2
7. On the compute2 start listen traffic from vm1 fixed ip on
    tap interface of vm3
8. Go to the vm1's console and initiate broadcast traffic to vm3
9. Check that ARP traffic appears on listened interface
10. On the compute2 start listen traffic from vm1 fixed ip om
    tap interface of vm2
11. Go to the vm1's console and initiate broadcast traffic to vm3
12. Check that ARP traffic is absent on listened interface
