### PR TITLE
Fix OpenStack client versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ paramiko>=1.16.0
 pytest
 pytest-xdist
 python-glanceclient==0.17.1
-python-keystoneclient>=2.0.0
-python-novaclient>=2.27.0
+python-keystoneclient>1.3.3,<2.0.0
+python-novaclient>=2.27.0,<3.0.0
 python-cinderclient>=1.0.5
 python-neutronclient>=2.0
 python-heatclient>=0.2.12


### PR DESCRIPTION
In some tests fresh OpenStack API clients aren't work as expected.
This commit fixed it to worked versions.
