### PR TITLE
Add testcase 'Check North-South connectivity'

### DIFF
--- a/doc/mos_tests/neutron.rst
+++ b/doc/mos_tests/neutron.rst
@@ -6,6 +6,11 @@ Neutron tests
 General tests
 =============
 
+Base tests class
+----------------
+.. automodule:: mos_tests.neutron.python_tests.base
+   :members:
+
 Neutron DHCP Agent tests
 ------------------------
 .. automodule:: mos_tests.neutron.python_tests.test_ban_dhcp_agent
@@ -15,12 +20,23 @@ Neutron L3 Agent tests
 ----------------------
 .. automodule:: mos_tests.neutron.python_tests.test_l3_agent
    :members:
-   
+
+OVS tests
+-----------
+.. automodule:: mos_tests.neutron.python_tests.test_ovs_restart
+   :members:
+
 Network specific tests
 ======================
 
 VxLan tests
 -----------
 .. automodule:: mos_tests.neutron.python_tests.test_vxlan
+   :members:
+
+
+DVR tests
+-----------
+.. automodule:: mos_tests.neutron.python_tests.test_dvr
    :members:
 

--- a/mos_tests/environment/fuel_client.py
+++ b/mos_tests/environment/fuel_client.py
@@ -96,19 +96,19 @@ class Environment(EnvironmentBase):
 
     @property
     def controllers_is_ready(self):
-        for node in self.get_nodes_by_role('controller'):
-            logger.debug('Check controller {} is alive'.format(
-                node.data['fqdn']))
-            with node.ssh() as remote:
-                for cmd in ('glance image-list', 'nova list',
-                            'openstack project list'):
-                    result = remote.execute('. openrc && {}'.format(cmd))
-                    if result['exit_code'] != 0:
-                        output = ''.join(result['stdout'] + result['stderr'])
-                        logger.debug(
-                            '{} return {} exit_code. Output:\n{}'.format(
-                            cmd, result['exit_code'], output))
-                        return False
+        node = self.get_nodes_by_role('controller')[0]
+        logger.debug('Check controller {} is alive'.format(
+            node.data['fqdn']))
+        with node.ssh() as remote:
+            for cmd in ('glance image-list', 'nova list',
+                        'openstack project list'):
+                result = remote.execute('. openrc && {}'.format(cmd))
+                if result['exit_code'] != 0:
+                    output = ''.join(result['stdout'] + result['stderr'])
+                    logger.debug(
+                        '{} return {} exit_code. Output:\n{}'.format(
+                        cmd, result['exit_code'], output))
+                    return False
         return True
 
     @property

--- a/mos_tests/environment/ssh.py
+++ b/mos_tests/environment/ssh.py
@@ -95,7 +95,7 @@ class SSHClient(object):
         self.clear()
 
     def connect(self):
-        logging.debug(
+        logger.debug(
             "Connect to '%s:%s' as '%s:%s'" % (
                 self.host, self.port, self.username, self.password))
         base_kwargs = dict(
@@ -112,7 +112,7 @@ class SSHClient(object):
             except paramiko.AuthenticationException:
                 continue
         if self.private_keys:
-            logging.error("Authentication with keys failed")
+            logger.error("Authentication with keys failed")
 
         return self._ssh.connect(self.host, **base_kwargs)
 
@@ -173,7 +173,7 @@ class SSHClient(object):
         return result
 
     def execute_async(self, command):
-        logging.debug("Executing command: '%s'" % command.rstrip())
+        logger.debug("Executing command: '%s'" % command.rstrip())
         chan = self._ssh.get_transport().open_session(timeout=120)
         stdin = chan.makefile('wb')
         stdout = chan.makefile('rb')

--- a/mos_tests/neutron/conftest.py
+++ b/mos_tests/neutron/conftest.py
@@ -65,6 +65,7 @@ def revert_snapshot(request, env_name, snapshot_name):
     if getattr(request.node, 'do_revert', True):
         DevopsClient.revert_snapshot(env_name=env_name,
                                      snapshot_name=snapshot_name)
+        setattr(request.node, 'do_revert', False)
 
 
 @pytest.fixture
@@ -117,6 +118,15 @@ def is_l2pop(env):
     with env.get_ssh_to_node(controller.data['ip']) as remote:
         result = remote.execute(cmd)
     return is_vxlan(env) and result['exit_code'] == 0
+
+
+def is_dvr(env):
+    """Env deployed with enabled distributed routers support"""
+    cmd = 'grep -q ^enable_distributed_routing=True /etc/neutron/plugin.ini'
+    controller = env.get_nodes_by_role('controller')[0]
+    with env.get_ssh_to_node(controller.data['ip']) as remote:
+        result = remote.execute(cmd)
+    return result['exit_code'] == 0
 
 
 @pytest.fixture(autouse=True)

--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -31,6 +31,7 @@ class NotFound(Exception):
 
 
 class TestBase(object):
+    """Class contains common methods for neutron tests"""
 
     @pytest.fixture(autouse=True)
     def init(self, fuel, env, os_conn):
@@ -84,62 +85,56 @@ class TestBase(object):
             subnet_id=subnet['subnet']['id'])
         return router
 
-    def run_on_vm(self, vm, vm_keypair, command, vm_login="cirros",
-                  timeout=3 * 60):
-        command = command.replace('"', r'\"')
-        net_name = [x for x in vm.addresses if len(vm.addresses[x]) > 0][0]
-        vm_ip = vm.addresses[net_name][0]['addr']
-        net_id = self.os_conn.neutron.list_networks(
-            name=net_name)['networks'][0]['id']
-        dhcp_namespace = "qdhcp-{0}".format(net_id)
-        devops_node = self.get_node_with_dhcp(net_id)
-        _ip = devops_node.data['ip']
-        logger.info('Connect to {ip}'.format(ip=_ip))
-        with self.env.get_ssh_to_node(_ip) as remote:
-            res = remote.execute(
-                'ip netns list | grep -q {0}'.format(dhcp_namespace)
-            )
-            if res['exit_code'] != 0:
-                raise Exception("Network namespace '{0}' doesn't exist on "
-                                "remote slave!".format(dhcp_namespace))
-            key_path = '/tmp/instancekey_rsa'
-            res = remote.execute(
-                'echo "{0}" > {1} ''&& chmod 400 {1}'.format(
-                    vm_keypair.private_key, key_path))
-            cmd = (
-                ". openrc; ip netns exec {ns} ssh -i {key_path}"
-                " -o 'StrictHostKeyChecking no'"
-                " {vm_login}@{vm_ip} \"{command}\""
-            ).format(
-                ns=dhcp_namespace,
-                key_path=key_path,
-                vm_login=vm_login,
-                vm_ip=vm_ip,
-                command=command)
+    def run_on_vm(self, vm, vm_keypair=None, command='uname',
+                  vm_login="cirros", timeout=3 * 60, vm_password='cubswin:)'):
+        """Execute command on vm and return dict with results
+
+        :param vm: server to execute command on
+        :param vm_keypair: keypair used dduring vm creating
+        :param command: command to execute
+        :param vm_login: username to login to vm via ssh
+        :param vm_password: password to login to vm via ssh
+        :param timeout: type - int or None
+            - if None - execite command and return results
+            - if int - wait `timeout` seconds until command exit_code will be 0
+        :returns: Dictionary with `exit_code`, `stdout`, `stderr` keys.
+            `Stdout` and `stderr` are list of strings
+        """
+        results = []
+
+        def execute():
+            with self.os_conn.ssh_to_instance(self.env, vm, vm_keypair,
+                                              username=vm_login,
+                                              password=vm_password) as remote:
+                result = remote.execute(command)
+                results.append(result)
+                return result
+
+        logger.info('Executing `{cmd}` on {vm_name}'.format(
+            cmd=command,
+            vm_name=vm.name))
+
+        if timeout is None:
+            execute()
+        else:
             err_msg = ("SSH command:\n{command}\n completed with exit code 0.")
-            results = []
-
-            def run(cmd):
-                results.append(remote.execute(cmd))
-                return results[-1]
-
-            logger.info('Executing `{cmd}` on {vm_name}'.format(
-                cmd=command,
-                vm_name=vm.name))
-            wait(lambda: run(cmd)['exit_code'] == 0,
+            wait(lambda: execute()['exit_code'] == 0,
                  sleep_seconds=(1, 60, 5), timeout_seconds=timeout,
-                 waiting_for=err_msg.format(command=cmd))
-            return results[-1]
+                 expected_exceptions=(Exception,),
+                 waiting_for=err_msg.format(command=command))
+        return results[-1]
 
-    def check_ping_from_vm(self, vm, vm_keypair, ip_to_ping=None,
-                           timeout=3 * 60):
+    def check_ping_from_vm(self, vm, vm_keypair=None, ip_to_ping=None,
+                           timeout=3 * 60, vm_login='cirros',
+                           vm_password='cubswin:)'):
         if ip_to_ping is None:
             ip_to_ping = [settings.PUBLIC_TEST_IP]
         if isinstance(ip_to_ping, six.string_types):
             ip_to_ping = [ip_to_ping]
         cmd_list = ["ping -c1 {0}".format(x) for x in ip_to_ping]
         cmd = ' && '.join(cmd_list)
-        res = self.run_on_vm(vm, vm_keypair, cmd, timeout=timeout)
+        res = self.run_on_vm(vm, vm_keypair, cmd, timeout=timeout,
+                             vm_login=vm_login, vm_password=vm_password)
         error_msg = (
             'Instance has no connectivity, exit code {exit_code},'
             'stdout {stdout}, stderr {stderr}'

--- a/mos_tests/neutron/python_tests/conftest.py
+++ b/mos_tests/neutron/python_tests/conftest.py
@@ -47,19 +47,12 @@ def env(fuel):
 @pytest.fixture
 def os_conn(env):
     """Openstack common actions"""
+    logger.info("Wait for OpenStack is waking up")
+    wait(env.is_ready, timeout_seconds=60 * 5,
+        waiting_for="OpenStack is ready")
     os_conn = OpenStackActions(
         controller_ip=env.get_primary_controller_ip(),
         cert=env.certificate)
-
-    def nova_ready():
-        hosts = os_conn.nova.availability_zones.find(zoneName="nova").hosts
-        return all(x['available'] for y in hosts.values()
-                   for x in y.values() if x['active'])
-
-    wait(nova_ready,
-         timeout_seconds=60 * 5,
-         expected_exceptions=Exception,
-         waiting_for="OpenStack nova computes is ready")
     return os_conn
 
 

--- a/mos_tests/neutron/python_tests/test_dvr.py
+++ b/mos_tests/neutron/python_tests/test_dvr.py
@@ -1,0 +1,66 @@
+#    Copyright 2015 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+
+import pytest
+
+from mos_tests.neutron.python_tests import base
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.check_env_('has_1_or_more_computes', 'is_dvr')
+@pytest.mark.usefixtures("setup")
+class TestDVR(base.TestBase):
+    """DVR specific test cases"""
+
+    @pytest.fixture
+    def variables(self, init):
+        """Init Openstack variables"""
+        self.zone = self.os_conn.nova.availability_zones.find(zoneName="nova")
+        self.security_group = self.os_conn.create_sec_group_for_ssh()
+        self.instance_keypair = self.os_conn.create_key(key_name='instancekey')
+
+    def test_vm_connectivity_wo_floating(self, variables):
+        """Check North-South connectivity (without floating IP)
+
+        Scenario:
+            1. Create net01, subnet net01__subnet for it
+            2. Create router01 with external network and
+                router type Distributed
+            3. Add interfaces to the router01 with net01__subnet
+            4. Boot vm_1 in the net01
+            5. Go to the vm_1
+            6. Ping 8.8.8.8
+        """
+        net, subnet = self.create_internal_network_with_subnet(1)
+        router = self.os_conn.create_router(name='router01', distributed=True)
+        self.os_conn.router_gateway_add(
+            router_id=router['router']['id'],
+            network_id=self.os_conn.ext_network['id'])
+
+        self.os_conn.router_interface_add(
+            router_id=router['router']['id'],
+            subnet_id=subnet['subnet']['id'])
+
+        server = self.os_conn.create_server(
+            name='server01',
+            availability_zone=self.zone.zoneName,
+            key_name=self.instance_keypair.name,
+            nics=[{'net-id': net['network']['id']}],
+            security_groups=[self.security_group.id])
+
+        self.check_ping_from_vm(server, vm_keypair=self.instance_keypair)

--- a/mos_tests/neutron/python_tests/test_ovs_restart.py
+++ b/mos_tests/neutron/python_tests/test_ovs_restart.py
@@ -137,16 +137,16 @@ class TestOVSRestartTwoVms(OvsBase):
         Steps:
             1. Update default security group
             2. Create router01, create networks net01: net01__subnet,
-            192.168.1.0/24, net02: net02__subnet, 192.168.2.0/24 and
-            attach them to router01.
+                192.168.1.0/24, net02: net02__subnet, 192.168.2.0/24 and
+                attach them to router01.
             3. Launch vm1 in net01 network and vm2 in net02 network
-            on different computes
+                on different computes
             4. Go to vm1 console and send pings to vm2
             5. Disable ovs-agents on all controllers, restart service
-            neutron-plugin-openvswitch-agent on all computes, and enable
-            them back. To do this, launch the script against master node.
+                neutron-plugin-openvswitch-agent on all computes, and enable
+                them back. To do this, launch the script against master node.
             6. Wait 30 seconds, send pings from vm1 to vm2 and check that
-            it is successful.
+                it is successful.
             7. Repeat steps 6-7 'count' argument times
 
         Duration 10m

--- a/mos_tests/neutron/python_tests/test_ovs_restart.py
+++ b/mos_tests/neutron/python_tests/test_ovs_restart.py
@@ -130,7 +130,8 @@ class TestOVSRestartTwoVms(OvsBase):
         self.check_ping_from_vm(self.server1, self.instance_keypair,
                                 self.server2_ip, timeout=2 * 60)
 
-    def test_ovs_restart_pcs_disable_enable(self):
+    @pytest.mark.parametrize('count', [1, 40], ids=['1x', '40x'])
+    def test_ovs_restart_pcs_disable_enable(self, count):
         """Restart openvswitch-agents with pcs disable/enable on controllers
 
         Steps:
@@ -146,20 +147,22 @@ class TestOVSRestartTwoVms(OvsBase):
             them back. To do this, launch the script against master node.
             6. Wait 30 seconds, send pings from vm1 to vm2 and check that
             it is successful.
+            7. Repeat steps 6-7 'count' argument times
 
         Duration 10m
 
         """
-        self.disable_ovs_agents_on_controller()
-        self.restart_ovs_agents_on_computes()
-        self.enable_ovs_agents_on_controllers()
+        for _ in range(count):
+            self.disable_ovs_agents_on_controller()
+            self.restart_ovs_agents_on_computes()
+            self.enable_ovs_agents_on_controllers()
 
-        # sleep is used to check that system will be stable for some time
-        # after restarting service
-        time.sleep(30)
+            # sleep is used to check that system will be stable for some time
+            # after restarting service
+            time.sleep(30)
 
-        self.check_ping_from_vm(self.server1, self.instance_keypair,
-                                self.server2_ip, timeout=2 * 60)
+            self.check_ping_from_vm(self.server1, self.instance_keypair,
+                                    self.server2_ip, timeout=2 * 60)
 
 
 @pytest.mark.check_env_('is_vlan')


### PR DESCRIPTION
Testcase checks North-South connectivity (without floating IP) on
environment, deployed with DVR

Scenario:
1. Create net01, subnet net01__subnet for it
2. Create router01 with external network and
    router type Distributed
3. Add interfaces to the router01 with net01__subnet
4. Boot vm_1 in the net01
5. Go to the vm_1
6. Ping 8.8.8.8
