### PR TITLE
Add testcases [DVR] Check North-South connectivity

### DIFF
--- a/mos_tests/environment/devops_client.py
+++ b/mos_tests/environment/devops_client.py
@@ -97,7 +97,7 @@ class DevopsClient(object):
             remote.execute(
                 'for i in {{1..{0}}}; do ('
                     'ssh node-$i "hwclock --hctosys"'
-                ') & done; wait'.format(slaves_count))
+                ') done'.format(slaves_count))
 
     @classmethod
     def restore_cluster(cls, env):
@@ -105,10 +105,10 @@ class DevopsClient(object):
             out = remote.execute(
                 "for i in $(fuel node | grep controller | awk '{print $1}'); "
                 "do (ssh node-$i '"
-                    "service nova-conductor restart; "
                     "crm_resource -P"
                 "') & done; wait")
             logger.debug(out)
+            assert out['exit_code'] == 0
 
     @classmethod
     def get_node_by_mac(cls, env_name, mac):

--- a/mos_tests/neutron/python_tests/conftest.py
+++ b/mos_tests/neutron/python_tests/conftest.py
@@ -53,6 +53,17 @@ def os_conn(env):
     os_conn = OpenStackActions(
         controller_ip=env.get_primary_controller_ip(),
         cert=env.certificate)
+
+    def nova_ready():
+        hosts = os_conn.nova.availability_zones.find(zoneName="nova").hosts
+        return all(x['available'] for y in hosts.values()
+                   for x in y.values() if x['active'])
+
+    wait(nova_ready,
+         timeout_seconds=60 * 5,
+         expected_exceptions=Exception,
+         waiting_for="OpenStack nova computes is ready")
+    logger.info("OpenStack is ready")
     return os_conn
 
 


### PR DESCRIPTION
Testcases checks North-South connectivity on environment deployed with
enabled distributed routers support:
- With and without assigning floating IP
- With distributed and centralized router

Scenario:
1. Create net01, subnet net01__subnet for it
2. Create router01 with external network and
    router type `dvr_router`
3. Add interfaces to the router01 with net01__subnet
4. Boot vm_1 in the net01
5. Add floationg ip if case of `floating_ip` arg is True
5. Go to the vm_1
6. Ping 8.8.8.8
