### PR TITLE
Add testcase Check West-East-Routing connectivity

### DIFF
--- a/mos_tests/environment/devops_client.py
+++ b/mos_tests/environment/devops_client.py
@@ -97,7 +97,7 @@ class DevopsClient(object):
             remote.execute(
                 'for i in {{1..{0}}}; do ('
                     'ssh node-$i "hwclock --hctosys"'
-                ') & done; wait'.format(slaves_count))
+                ') done'.format(slaves_count))
 
     @classmethod
     def restore_cluster(cls, env):
@@ -105,10 +105,10 @@ class DevopsClient(object):
             out = remote.execute(
                 "for i in $(fuel node | grep controller | awk '{print $1}'); "
                 "do (ssh node-$i '"
-                    "service nova-conductor restart; "
                     "crm_resource -P"
                 "') & done; wait")
             logger.debug(out)
+            assert out['exit_code'] == 0
 
     @classmethod
     def get_node_by_mac(cls, env_name, mac):

--- a/mos_tests/environment/ssh.py
+++ b/mos_tests/environment/ssh.py
@@ -38,6 +38,10 @@ class CalledProcessError(Exception):
 
 class SSHClient(object):
 
+    def __repr__(self):
+        orig = super(SSHClient, self).__repr__()
+        return '{} [{}:{}]'.format(orig, self.host, self.port)
+
     @property
     def _sftp(self):
         if self._sftp_client is None:

--- a/mos_tests/neutron/python_tests/conftest.py
+++ b/mos_tests/neutron/python_tests/conftest.py
@@ -53,6 +53,17 @@ def os_conn(env):
     os_conn = OpenStackActions(
         controller_ip=env.get_primary_controller_ip(),
         cert=env.certificate)
+
+    def nova_ready():
+        hosts = os_conn.nova.availability_zones.find(zoneName="nova").hosts
+        return all(x['available'] for y in hosts.values()
+                   for x in y.values() if x['active'])
+
+    wait(nova_ready,
+         timeout_seconds=60 * 5,
+         expected_exceptions=Exception,
+         waiting_for="OpenStack nova computes is ready")
+    logger.info("OpenStack is ready")
     return os_conn
 
 


### PR DESCRIPTION
Testcase checks West-East-Routing connectivity with floatingIP after ban
and clear l3-agent on compute

Scenario:
1. Create net01, subnet net01__subnet for it
2. Create net02, subnet net02__subnet for it
3. Create router01_02 with router type Distributed and
    with gateway to external network
4. Add interfaces to the router01_02 with net01_subnet
    and net02_subnet
5. Boot vm_1 in the net01
6. Boot vm_2 in the net02 on different compute
7. Ban l3-agent on the compute with vm_1: service l3-agent stop
8. Wait some minutes
9. Clear this l3-agent: service l3-agent stop
10. Go to vm_1
11. Ping vm_2 with internal IP
