### PR TITLE
Add testcase 'Ban l3-agent with ACTIVE ha_state'

### DIFF
--- a/doc/mos_tests/neutron.rst
+++ b/doc/mos_tests/neutron.rst
@@ -40,3 +40,8 @@ DVR tests
 .. automodule:: mos_tests.neutron.python_tests.test_dvr
    :members:
 
+L3 HA tests
+-----------
+.. automodule:: mos_tests.neutron.python_tests.test_l3_ha
+   :members:
+

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -176,7 +176,7 @@ class OpenStackActions(object):
 
     def is_server_ssh_ready(self, server):
         """Check ssh connect to server"""
-        paramiko_logger = logging.getLogger("paramiko")
+        paramiko_logger = logging.getLogger("paramiko.transport")
         try:
             paramiko_logger.setLevel('CRITICAL')
             self.ssh_to_instance(self.env, server)

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -181,11 +181,13 @@ class OpenStackActions(object):
             paramiko_logger.setLevel('CRITICAL')
             self.ssh_to_instance(self.env, server)
         except paramiko.SSHException as e:
-            if 'No authentication methods available' in e:
+            if 'authentication' in unicode(e).lower():
                 return True
             else:
                 logger.debug('Instance unavaliable yet: {}'.format(e))
                 return False
+        except Exception as e:
+            logger.error(e)
         finally:
             paramiko_logger.setLevel('DEBUG')
 

--- a/mos_tests/environment/ssh.py
+++ b/mos_tests/environment/ssh.py
@@ -158,7 +158,7 @@ class SSHClient(object):
             raise CalledProcessError(command, errors)
 
     def execute(self, command, verbose=False):
-        chan, stdin, stderr, stdout = self.execute_async(command)
+        chan, stdin, stdout, stderr = self.execute_async(command)
         result = {
             'stdout': [],
             'stderr': [],
@@ -191,7 +191,7 @@ class SSHClient(object):
                 stdin.flush()
         else:
             chan.exec_command(cmd)
-        return chan, stdin, stderr, stdout
+        return chan, stdin, stdout, stderr
 
     def mkdir(self, path):
         if self.exists(path):

--- a/mos_tests/neutron/__init__.py
+++ b/mos_tests/neutron/__init__.py
@@ -15,16 +15,9 @@
 import logging
 import logging.config
 
-
-# suppress iso8601 and paramiko debug logging
-class NoDebugMessageFilter(logging.Filter):
-    def filter(self, record):
-        return not record.levelno <= logging.DEBUG
-
-logging.getLogger('paramiko.transport').addFilter(NoDebugMessageFilter())
-logging.getLogger('paramiko.hostkeys').addFilter(NoDebugMessageFilter())
-logging.getLogger('iso8601.iso8601').addFilter(NoDebugMessageFilter())
-
+logging.getLogger("paramiko.transport").setLevel(logging.WARNING)
+logging.getLogger("paramiko.hostkeys").setLevel(logging.INFO)
+logging.getLogger("iso8601.iso8601").setLevel(logging.INFO)
 
 logging.config.dictConfig({
     'version': 1,
@@ -35,20 +28,14 @@ logging.config.dictConfig({
             'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
         },
     },
-    'filters': {
-        'mos_tests': {
-            'class': 'logging.Filter',
-            'name': 'mos_tests',
-        }
-    },
     'handlers': {
         'console': {
-            'level': 'INFO',
+            'level': logging.INFO,
             'class': 'logging.StreamHandler',
             'formatter': 'standart',
         },
         'file': {
-            'level': 'DEBUG',
+            'level': logging.DEBUG,
             'class': 'logging.FileHandler',
             'filename': 'neutron.log',
             'formatter': 'standart',
@@ -57,13 +44,11 @@ logging.config.dictConfig({
     'loggers': {
         '': {
             'handlers': ['file'],
-            'level': 'DEBUG',
-            'propagate': True,
+            'level': logging.DEBUG,
         },
         'mos_tests': {
             'handlers': ['console'],
-            'level': 'INFO',
-            'filters': ['mos_tests']
+            'level': logging.DEBUG,
         }
     }
 })

--- a/mos_tests/neutron/python_tests/test_ban_dhcp_agent.py
+++ b/mos_tests/neutron/python_tests/test_ban_dhcp_agent.py
@@ -692,7 +692,7 @@ class TestBanDHCPAgentWithSettings(TestBaseDHCPAgent):
         return res
 
     def _prepare_neutron_server_and_env(self, net_count):
-        """ Prepares neutron service network count on dhcp agent
+        """Prepares neutron service network count on dhcp agent
             and prepares env.
 
         :param net_count: how many networks musth dhcp agent handle

--- a/mos_tests/neutron/python_tests/test_ovs_restart.py
+++ b/mos_tests/neutron/python_tests/test_ovs_restart.py
@@ -19,8 +19,8 @@ import time
 
 import pytest
 
-from mos_tests import settings
 from mos_tests.neutron.python_tests.base import TestBase
+from mos_tests import settings
 
 logger = logging.getLogger(__name__)
 
@@ -613,7 +613,7 @@ class TestOVSRestartWithIperfTraffic(OvsBase):
     """Restart ovs-agents with iperf traffic background"""
 
     def create_image(self, full_path):
-        """
+        """Create image
 
         :param full_path: full path to image file
         :return: image object for Glance
@@ -627,7 +627,7 @@ class TestOVSRestartWithIperfTraffic(OvsBase):
         return image
 
     def get_lost_percentage(self, output):
-        """
+        """Get lost percentage
 
         :param output: list of lines (output of iperf client)
         :return: percentage of lost datagrams


### PR DESCRIPTION
Testcase checks that after ban l3 agent with ACTIVE ha_state for router
ping loss will be not more than 10 packets

Scenario:
1. Create network1, network2
2. Create router1 and connect it with network1, network2 and
    external net
3. Boot vm1 in network1
4. Boot vm2 in network2 and associate floating ip
5. Add rules for ping
6. Check what one agent has ACTIVE ha_state
    and other has STANDBY state
7. Start ping vm2 from vm1 by floating ip
8. Ban agent with ACTIVE state from step 6
9. Stop ping
10. Check that ping lost no more than 10 packets
