### PR TITLE
Add testcase Disable all l3 agents and enable them

### DIFF
--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -177,8 +177,9 @@ class OpenStackActions(object):
     def is_server_ssh_ready(self, server):
         """Check ssh connect to server"""
         paramiko_logger = logging.getLogger("paramiko.transport")
+        paramiko_orig_level = paramiko_logger.getEffectiveLevel()
         try:
-            paramiko_logger.setLevel('CRITICAL')
+            paramiko_logger.setLevel(logging.CRITICAL)
             self.ssh_to_instance(self.env, server)
         except paramiko.SSHException as e:
             if 'authentication' in unicode(e).lower():
@@ -189,7 +190,7 @@ class OpenStackActions(object):
         except Exception as e:
             logger.error(e)
         finally:
-            paramiko_logger.setLevel('DEBUG')
+            paramiko_logger.setLevel(paramiko_orig_level)
 
     def get_nova_instance_ips(self, srv):
         """Return all nova instance ip addresses as dict
@@ -603,17 +604,17 @@ class OpenStackActions(object):
 
     def wait_agents_alive(self, agt_ids_to_check):
         logger.info('waiting until the agents get alive')
-        assert(wait(lambda: all([agt['alive'] for agt in
+        wait(lambda: all(agt['alive'] for agt in
                                   self.neutron.list_agents()['agents']
-                                  if agt['id'] in agt_ids_to_check]),
-                    timeout_seconds=5 * 60))
+                                  if agt['id'] in agt_ids_to_check),
+             timeout_seconds=5 * 60)
 
     def wait_agents_down(self, agt_ids_to_check):
         logger.info('waiting until the agents go down')
-        assert(wait(lambda: all([not agt['alive'] for agt in
+        wait(lambda: all(not agt['alive'] for agt in
                                   self.neutron.list_agents()['agents']
-                                  if agt['id'] in agt_ids_to_check]),
-                    timeout_seconds=5 * 60))
+                                  if agt['id'] in agt_ids_to_check),
+             timeout_seconds=5 * 60)
 
     def add_net(self, router_id):
         i = len(self.neutron.list_networks()['networks']) + 1


### PR DESCRIPTION
Testcase check ping from one vm to another after disabling all l3 agents
and enabling them after

Scenario:
1. Create network1, network2
2. Create router1 and connect it with network1, network2 and
    external net
3. Boot vm1 in network1
4. Boot vm2 in network2 and associate floating ip
5. Add rules for ping
6. Disable all p_neutron-l3-agent
7. Wait until all agents died
8. Enable all p_neutron-l3-agent
9. Wait until all agents alive
10. Check ping vm2 from vm1 by floating ip
