### PR TITLE
Add testcase 'Destroy primary controller'

### DIFF
--- a/mos_tests/environment/fuel_client.py
+++ b/mos_tests/environment/fuel_client.py
@@ -37,6 +37,12 @@ class NodeProxy(object):
     def __getattr__(self, name):
         return getattr(self._orig_node, name)
 
+    def __eq__(self, other):
+        return self.data['ip'] == other.data['ip']
+
+    def __ne__(self, other):
+        return not(self == other)
+
     @property
     def ip_list(self):
         """Returns node ip addresses list"""


### PR DESCRIPTION
Testcase checks that after destroy active l3 agent on primary controller
ping will not loss more than 20 packets.
1. Create network1, network2
2. Create router1 and connect it with network1, network2 and
   external net
3. Boot vm1 in network1
4. Boot vm2 in network2 and associate floating ip
5. Add rules for ping
6. Find node with active ha_state for router
7. If node from step 6 isn't primary controller,
   reschedule router1 to primary by banning all another
   and then clear them
8. Start ping vm2 from vm1 by floating ip
9. Destroy primary controller
10. Stop ping
11. Check that ping lost no more than 10 packets
