### PR TITLE
Added 4 tests.

### DIFF
--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -174,6 +174,25 @@ class TestBase(object):
                              vm_login=vm_login, vm_password=vm_password)
         return res
 
+    def check_ping_from_vm_with_ip(self, vm_ip, vm_keypair=None, ip_to_ping=None,
+                                   ping_count=1, vm_login='cirros',
+                                   vm_password='cubswin:)'):
+        if ip_to_ping is None:
+            ip_to_ping = [settings.PUBLIC_TEST_IP]
+        if isinstance(ip_to_ping, six.string_types):
+            ip_to_ping = [ip_to_ping]
+        pkeys = self.convert_private_key_for_vm([vm_keypair.private_key])
+        cmd_list = ["ping -c{0} {1}".format(ping_count, x) for x in ip_to_ping]
+        with self.env.get_ssh_to_vm(vm_ip, private_keys=pkeys,
+                                    username=vm_login,
+                                    password=vm_password) as vm_remote:
+            res = vm_remote.execute(' && '.join(cmd_list))
+            assert 0 == res['exit_code'], \
+                ('Ping is not successful, exit code {0},'
+                 'stdout {1}, stderr {2}'.format(res['exit_code'],
+                                                 res['stdout'],
+                                                 res['stderr']))
+
     def check_vm_connectivity(self, timeout=3 * 60):
         """Check that all vms can ping each other and public ip"""
         servers = self.os_conn.get_servers()

--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -174,8 +174,9 @@ class TestBase(object):
                              vm_login=vm_login, vm_password=vm_password)
         return res
 
-    def check_ping_from_vm_with_ip(self, vm_ip, vm_keypair=None, ip_to_ping=None,
-                                   ping_count=1, vm_login='cirros',
+    def check_ping_from_vm_with_ip(self, vm_ip, vm_keypair=None,
+                                   ip_to_ping=None, ping_count=1,
+                                   vm_login='cirros',
                                    vm_password='cubswin:)'):
         if ip_to_ping is None:
             ip_to_ping = [settings.PUBLIC_TEST_IP]


### PR DESCRIPTION
```
Check North-South connectivity with floatingIP after shut-downing
br-ex on all controllers

Scenario:
1. Create net01, subnet net01__subnet for it
2. Create router01 with external network and router type Distributed
3. Add interfaces to the router01 with net01__subnet
4. Boot vm_1 in the net01
5. Associate floating IP
6. Go to the vm_1 with ssh and floating IP
7. Shut down br-ex on all controllers
8. Go to the vm_1 with ssh and floating IP
9. Ping 8.8.8.8

Check North-South connectivity with floatingIP after ban and
clear l3-agent on compute

Scenario:
1. Create net01, subnet net01__subnet for it
2. Create router01 with external network and router type Distributed
3. Add interfaces to the router01 with net01__subnet
4. Boot vm_1 in the net01
5. Associate floating IP
6. Go to the vm_1 with ssh and floating IP
7. Ping 8.8.8.8
8. Ban l3-agent on the compute with vm_1: service l3-agent stop
9. Wait 15 seconds
10. Clear this l3-agent: service l3-agent stop
11. Go to vm_1 with ssh and floating IP
12. Ping 8.8.8.8

Check East-West connectivity after destroy controller

Scenario:
1. Create net01, subnet net01__subnet for it
2. Create net02, subnet net02__subnet for it
3. Create router01_02 with router type Distributed and
with gateway to external network
4. Add interfaces to the router01_02 with net01_subnet and net02_subnet
5. Boot vm_1 in the net01
6. Boot vm_2 in the net02
7. Check that VMs are on the different computes (otherwise migrate
one of them to another compute: nova migrate <your_vm>)
8. Go to the vm_1
9. Ping vm_2
10. Destroy one controller
11. Go to the vm_2 with internal ip from namespace on compute
12. Ping vm_1 with internal IP

Check East-West connectivity with instances on the same host

Scenario:
1. Create net01, subnet net01__subnet for it
2. Create net02, subnet net02__subnet for it
3. Create router01_02 with router type Distributed and
with gateway to external network
4. Add interfaces to the router01_02 with net01_subnet
and net02_subnet
5. Boot vm_1 in the net01 (with
--availability-zone nova:node-i.domain.tld
parameter for command nova boot)
6. Boot vm_2 in the net02 on the same node-compute
7. Check that VMs are on the same computes
(otherwise migrate one of them to another compute:
nova migrate <your_vm>)
8. Go to the vm_1
9. Ping vm_2
```
