### PR TITLE
Add testcase 'Ban agent for many routers'

### DIFF
--- a/mos_tests/environment/fuel_client.py
+++ b/mos_tests/environment/fuel_client.py
@@ -37,6 +37,12 @@ class NodeProxy(object):
     def __getattr__(self, name):
         return getattr(self._orig_node, name)
 
+    def __eq__(self, other):
+        return self.data['ip'] == other.data['ip']
+
+    def __ne__(self, other):
+        return not(self == other)
+
     @property
     def ip_list(self):
         """Returns node ip addresses list"""


### PR DESCRIPTION
Testcase checks ping after ban l3 agent on what router between 2 vms
placed.
Scenario:
1. Create 19 nets, subnets, routers.
2. Create network20, network21
3. Create router20_21 and connect it with network20, network21
4. Boot vm1 in network20
5. Boot vm2 in network21
6. Add rules for ping
7. Start ping beetween vms
8. Ban active agent for router between vms
9. Check lost pings not more 10 packets
