### PR TITLE
Fix for test_heat_create_stack_docker_resources

### DIFF
--- a/mos_tests/heat/images/fedora_22-docker-image.qcow2.txt
+++ b/mos_tests/heat/images/fedora_22-docker-image.qcow2.txt
@@ -1,4 +1,0 @@
-http://NEED/TO/PUT/TO/THE/PUBLIC/LOCATION/fedora-software-config.qcow2
-# NEED INTERNET LINK HERE
-now it is here:
-cz7777.bud.mirantis.net: /home/akoryagin/MOS/build_image/fedora-software-config.qcow2

--- a/mos_tests/settings.py
+++ b/mos_tests/settings.py
@@ -35,3 +35,4 @@ PUBLIC_TEST_IP = os.environ.get('PUBLIC_TEST_IP', '8.8.8.8')
 # Path to folder with required images
 TEST_IMAGE_PATH = os.path.expanduser('~/images')
 UBUNTU_IPERF_QCOW2 = 'ubuntu-iperf.qcow2'
+FEDORA_DOCKER_QCOW2 = 'fedora-software-config.qcow2'


### PR DESCRIPTION
If no image could be found on the node, then test is skipped
