### PR TITLE
Add Glance CLI tests for image create-delete

### DIFF
--- a/mos_tests/conftest.py
+++ b/mos_tests/conftest.py
@@ -111,8 +111,9 @@ def cleanup(request, env_name, snapshot_name):
     destructive = 'undestructive' not in item.keywords
     reverted = False
     if failed or (not skipped and destructive):
-        revert_snapshot(env_name, snapshot_name)
-        reverted = True
+        if all([env_name, snapshot_name]):
+            revert_snapshot(env_name, snapshot_name)
+            reverted = True
     setattr(item.nextitem, 'reverted', reverted)
 
 

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -27,11 +27,11 @@ from novaclient import client as nova_client
 from novaclient.exceptions import ClientException as NovaClientException
 import paramiko
 import six
-from tempest_lib.cli import output_parser
 
 from mos_tests.environment.ssh import SSHClient
 from mos_tests.functions.common import gen_temp_file
 from mos_tests.functions.common import wait
+from mos_tests.functions import os_cli
 
 logger = logging.getLogger(__name__)
 
@@ -703,30 +703,28 @@ class OpenStackActions(object):
              timeout_seconds=5 * 60,
              waiting_for="network reschedule to new dhcp agent")
 
-    def _keystone_run(self, command, *args, **kwargs):
-        controller = self.env.get_nodes_by_role('controller')[0]
-        args
-        kwargs_tuple = tuple("--{0} '{1}'".format(k, v)
-                             for k, v in kwargs.items())
-        args = args + kwargs_tuple
-        with controller.ssh() as remote:
-            return remote.check_call(
-                '. openrc && keystone {command} {args}'.format(
-                    command=command, args=' '.join(args)))
+    def _get_controller(self):
+        # TODO(gdyuldin) remove this methods after moving to functions.os_cli
+        return self.env.get_nodes_by_role('controller')[0]
 
     def tenant_create(self, name):
-        output = self._keystone_run('tenant-create', name=name)
-        return output_parser.details(''.join(output['stdout']))
+        # TODO(gdyuldin) remove this methods after moving to functions.os_cli
+        with self._get_controller().ssh() as remote:
+            return os_cli.OpenStack(remote).tenant_create(name=name)
 
     def tenant_delete(self, name):
-        return self._keystone_run('tenant-delete', name)
+        # TODO(gdyuldin) remove this methods after moving to functions.os_cli
+        with self._get_controller().ssh() as remote:
+            return os_cli.OpenStack(remote).tenant_delete(name=name)
 
     def user_create(self, name, password, tenant=None):
-        kwargs = {'name': name, 'pass': password}
-        if tenant is not None:
-            kwargs['tenant'] = tenant
-        output = self._keystone_run('user-create', **kwargs)
-        return output_parser.details(''.join(output['stdout']))
+        # TODO(gdyuldin) remove this methods after moving to functions.os_cli
+        with self._get_controller().ssh() as remote:
+            return os_cli.OpenStack(remote).user_create(name=name,
+                                                       password=password,
+                                                       tenant=tenant)
 
     def user_delete(self, name):
-        return self._keystone_run('user-delete', name)
+        # TODO(gdyuldin) remove this methods after moving to functions.os_cli
+        with self._get_controller().ssh() as remote:
+            return os_cli.OpenStack(remote).user_delete(name=name)

--- a/mos_tests/functions/os_cli.py
+++ b/mos_tests/functions/os_cli.py
@@ -1,0 +1,75 @@
+#    Copyright 2015 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+
+from tempest_lib import exceptions
+
+
+def os_execute(remote, command, fail_ok=False, merge_stderr=False):
+    command = '. openrc && {}'.format(command)
+    result = remote.execute(command)
+    if not fail_ok and not result.is_ok:
+        raise exceptions.CommandFailed(result['exit_code'],
+                                       command,
+                                       result.stdout_string,
+                                       result.stderr_string)
+    output = ''
+    if merge_stderr:
+        output += result.stderr_string
+    return output + result.stdout_string
+
+
+class CLICLient(object):
+
+    command = ''
+
+    def __init__(self, remote):
+        self.remote = remote
+        super(CLICLient, self).__init__()
+
+    def build_command(self, action, flags='', params=''):
+        return ' '.join([self.command, flags, action, params])
+
+    def execute(self, action, flags='', params='', fail_ok=False,
+                merge_stderr=False):
+        command = self.build_command(action, flags, params)
+        return os_execute(self.remote, command, fail_ok=fail_ok,
+                          merge_stderr=merge_stderr)
+
+    def details(self, output):
+        return {x['Field']: x['Value'] for x in json.loads(output)}
+
+
+class OpenStack(CLICLient):
+    command = 'openstack'
+
+    def project_create(self, name):
+        output = self.execute('project create',
+                              params='{} -f json'.format(name))
+        return self.details(output)
+
+    def project_delete(self, name):
+        return self.execute('project delete', params=name)
+
+    def user_create(self, name, password, project=None):
+        params = '{name} --password {password} -f json'.format(
+            name=name, password=password)
+        if project is not None:
+            params += ' --project {}'.format(project)
+        output = self.execute('user create', params=params)
+        return self.details(output)
+
+    def user_delete(self, name):
+        return self.execute('user delete', params=name)

--- a/mos_tests/glance/conftest.py
+++ b/mos_tests/glance/conftest.py
@@ -20,6 +20,11 @@ from tempest_lib.cli import base
 
 
 @pytest.fixture
+def suffix():
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
 def cli(os_conn):
     return base.CLIClient(username=os_conn.username,
                           password=os_conn.password,
@@ -42,3 +47,21 @@ def image_file():
         f.seek(10 * (1024 ** 2))  # 10 MB
         f.write(' ')
         yield f.name
+
+
+@pytest.yield_fixture
+def tenant(os_conn, suffix):
+    tenant_name = "tenant_{}".format(suffix[:6])
+    tenant = os_conn.tenant_create(tenant_name)
+    yield tenant
+    os_conn.tenant_delete(tenant_name)
+
+
+@pytest.yield_fixture
+def user(os_conn, suffix, tenant):
+    name = "user_{}".format(suffix[:6])
+    password = "password"
+    user = os_conn.user_create(name=name, password=password,
+                               tenant=tenant['id'])
+    yield user
+    os_conn.user_delete(name)

--- a/mos_tests/glance/conftest.py
+++ b/mos_tests/glance/conftest.py
@@ -1,0 +1,44 @@
+#    Copyright 2016 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from functools import partial
+import tempfile
+
+import pytest
+from tempest_lib.cli import base
+
+
+@pytest.fixture
+def cli(os_conn):
+    return base.CLIClient(username=os_conn.username,
+                          password=os_conn.password,
+                          tenant_name=os_conn.tenant,
+                          uri=os_conn.keystone.auth_url,
+                          cli_dir='.tox/glance/bin',
+                          insecure=os_conn.insecure)
+
+
+@pytest.fixture(params=['1', '2'], ids=['api v1', 'api v2'])
+def glance(request, os_conn, cli):
+    flags = '--os-cacert {0.path_to_cert} --os-image-api-version {1}'.format(
+        os_conn, request.param)
+    return partial(cli.glance, flags=flags)
+
+
+@pytest.yield_fixture
+def image_file():
+    with tempfile.NamedTemporaryFile(delete=True) as f:
+        f.seek(10 * (1024 ** 2))  # 10 MB
+        f.write(' ')
+        yield f.name

--- a/mos_tests/glance/negative_test.py
+++ b/mos_tests/glance/negative_test.py
@@ -12,50 +12,21 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from functools import partial
-import os
-import subprocess
+
 import uuid
 
 import pytest
-from tempest_lib.cli import base
 from tempest_lib.cli import output_parser as parser
 
 
 pytestmark = pytest.mark.undestructive
 
 
-@pytest.fixture
-def cli(os_conn):
-    return base.CLIClient(username=os_conn.username,
-                          password=os_conn.password,
-                          tenant_name=os_conn.tenant,
-                          uri=os_conn.keystone.auth_url,
-                          cli_dir='.tox/glance/bin',
-                          insecure=os_conn.insecure)
-
-
-@pytest.fixture(params=['1', '2'], ids=['api v1', 'api v2'])
-def glance(request, os_conn, cli):
-    flags = '--os-cacert {0.path_to_cert} --os-image-api-version {1}'.format(
-        os_conn, request.param)
-    return partial(cli.glance, flags=flags)
-
-
-@pytest.yield_fixture
-def fake_image():
-    image_name = "image_{}".format(str(uuid.uuid4())[:4])
-    subprocess.check_call('fallocate -l 100MB {}'.format(image_name),
-                          shell=True)
-    yield image_name
-    os.remove(image_name)
-
-
-def test_upload_image_wo_disk_format_and_container_format(fake_image, glance):
+def test_upload_image_wo_disk_format_and_container_format(image_file, glance):
     """Checks that disk-format and container-format are required"""
     name = 'Test_{0}'.format(str(uuid.uuid4())[:6])
     cmd = 'image-create --name {name} --file {path} --progress'.format(
-        name=name, path=fake_image)
+        name=name, path=image_file)
     out = glance(cmd, fail_ok=True, merge_stderr=True)
     assert 'error: Must provide' in out
     assert '--container-format' in out

--- a/mos_tests/glance/sanity_test.py
+++ b/mos_tests/glance/sanity_test.py
@@ -1,0 +1,41 @@
+#    Copyright 2016 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import uuid
+
+import pytest
+from tempest_lib.cli import output_parser as parser
+
+
+@pytest.mark.parametrize('glance', [1], indirect=['glance'])
+def test_update_raw_data_in_image(glance, image_file):
+    """Checks updating raw data in Glance image"""
+    name = "Test_{0}".format(str(uuid.uuid4())[:6])
+    cmd = ("image-create --name {name} --container-format bare --disk-format "
+           "qcow2".format(name=name))
+    image = parser.details(glance(cmd))
+    image_data = parser.details(glance('image-show {id}'.format(**image)))
+    assert image_data['status'] == 'queued'
+
+    image_list = parser.listing(glance('image-list'))
+    assert image['id'] in [x['ID'] for x in image_list]
+
+    glance('image-update --file {file} --progress {id}'.format(
+        file=image_file, **image))
+    image_data = parser.details(glance('image-show {id}'.format(**image)))
+    assert image_data['status'] == 'active'
+
+    glance('image-delete {id}'.format(**image))
+    image_list = parser.listing(glance('image-list'))
+    assert image['id'] not in [x['ID'] for x in image_list]

--- a/mos_tests/glance/sanity_test.py
+++ b/mos_tests/glance/sanity_test.py
@@ -12,30 +12,99 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import uuid
-
 import pytest
 from tempest_lib.cli import output_parser as parser
 
 
+def check_image_in_list(glance, image):
+    __tracebackhide__ = True
+    image_list = parser.listing(glance('image-list'))
+    if image['id'] not in [x['ID'] for x in image_list]:
+        pytest.fail('There is no image {id} in list'.format(**image))
+
+
+def check_image_not_in_list(glance, image):
+    __tracebackhide__ = True
+    image_list = parser.listing(glance('image-list'))
+    if image['id'] in [x['ID'] for x in image_list]:
+        pytest.fail('There is image {id} in list'.format(**image))
+
+
+def check_image_active(glance, image):
+    __tracebackhide__ = True
+
+    image_data = parser.details(glance('image-show {id}'.format(**image)))
+    if image_data['status'] != 'active':
+        pytest.fail('Image {id} status is {status} (not active)'.format(
+            **image_data))
+
+
 @pytest.mark.parametrize('glance', [1], indirect=['glance'])
-def test_update_raw_data_in_image(glance, image_file):
-    """Checks updating raw data in Glance image"""
-    name = "Test_{0}".format(str(uuid.uuid4())[:6])
+def test_update_raw_data_in_image(glance, image_file, suffix):
+    """Checks updating raw data in Glance image
+
+    Scenario:
+        1. Create image
+        2. Check that image is present in list and image status is `quened`
+        3. Update image with `image_file`
+        4. Check that image status changes to `active`
+        5. Delete image
+        6. Check that image deleted
+    """
+    name = "Test_{0}".format(suffix[:6])
     cmd = ("image-create --name {name} --container-format bare --disk-format "
            "qcow2".format(name=name))
     image = parser.details(glance(cmd))
     image_data = parser.details(glance('image-show {id}'.format(**image)))
     assert image_data['status'] == 'queued'
 
-    image_list = parser.listing(glance('image-list'))
-    assert image['id'] in [x['ID'] for x in image_list]
+    check_image_in_list(glance, image)
 
     glance('image-update --file {file} --progress {id}'.format(
         file=image_file, **image))
-    image_data = parser.details(glance('image-show {id}'.format(**image)))
-    assert image_data['status'] == 'active'
+    check_image_active(glance, image)
 
     glance('image-delete {id}'.format(**image))
-    image_list = parser.listing(glance('image-list'))
-    assert image['id'] not in [x['ID'] for x in image_list]
+
+    check_image_not_in_list(glance, image)
+
+
+def test_share_glance_image(glance, user, tenant, image_file, suffix):
+    """Check sharing glance image to another tenant
+
+    Scenario:
+        1. Create image from `image_file`
+        2. Check that image is present in list and image status is `active`
+        3. Bind another tenant to image
+        4. Check that binded tenant id is present in image member list
+        5. Unbind tenant from image
+        6. Check that tenant id is not present in image member list
+        7. Delete image
+        8. Check that image deleted
+    """
+    name = "Test_{0}".format(suffix[:6])
+    cmd = ("image-create --name {name} --container-format bare --disk-format "
+           "qcow2 --file {file} --progress".format(name=name, file=image_file))
+    image = parser.details(glance(cmd))
+
+    check_image_active(glance, image)
+
+    check_image_in_list(glance, image)
+
+    glance('member-create {id} {tenant_id}'.format(tenant_id=tenant['id'],
+                                                   **image))
+
+    member_list = parser.listing(glance('member-list --image-id {id}'.format(
+        **image)))
+    assert tenant['id'] in [x['Member ID'] for x in member_list]
+
+    glance('member-delete {id} {tenant_id}'.format(tenant_id=tenant['id'],
+                                                   **image))
+
+    member_list = parser.listing(glance('member-list --image-id {id}'.format(
+        **image)))
+    assert tenant['id'] not in [x['Member ID'] for x in member_list]
+
+    glance('image-delete {id}'.format(**image))
+
+    check_image_not_in_list(glance, image)

--- a/mos_tests/settings.py
+++ b/mos_tests/settings.py
@@ -40,3 +40,8 @@ FEDORA_DOCKER_QCOW2 = 'fedora-software-config.qcow2'
 WIN_SERVER_QCOW2 = 'windows_server_2012_r2_standard_eval_kvm_20140607.qcow2'
 
 CONSOLE_LOG_LEVEL = os.environ.get('LOG_LEVEL', logging.DEBUG)
+
+# Glance tests settings
+GLANCE_IMAGE_URL = os.environ.get(
+    'GLANCE_IMAGE_URL',
+    'http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img')

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ six
 sphinx==1.3.1
 tox
 waiting
+tempest_lib

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,5 @@ commands=
 [testenv:glance]
 deps=
     -r{toxinidir}/requirements.txt
-    tempest_lib
 commands=
     py.test {toxinidir}/mos_tests/glance {posargs} --capture=sys


### PR DESCRIPTION
This tests check Glance CLI operations for image create (from local
file and remote URL) with both v1 and v2 API versions.
