### PR TITLE
Add Glance CLI test to exceed token lifetime

### DIFF
--- a/mos_tests/functions/common.py
+++ b/mos_tests/functions/common.py
@@ -615,3 +615,11 @@ def gen_temp_file(prefix='tmp', suffix=''):
     tempdir = os.path.join(os.path.dirname(__file__), '../../temp')
     return NamedTemporaryFile(prefix=prefix, suffix=suffix, dir=tempdir,
                               delete=False)
+
+
+def get_os_conn(environment):
+    from mos_tests.environment.os_actions import OpenStackActions
+
+    return OpenStackActions(
+        controller_ip=environment.get_primary_controller_ip(),
+        cert=environment.certificate, env=environment)

--- a/mos_tests/functions/os_cli.py
+++ b/mos_tests/functions/os_cli.py
@@ -14,7 +14,7 @@
 
 import json
 
-from tempest_lib import exceptions
+from tempest.lib import exceptions
 
 
 def os_execute(remote, command, fail_ok=False, merge_stderr=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ six
 sphinx==1.3.1
 tox
 waiting
-tempest_lib
+git+git://github.com/openstack/tempest


### PR DESCRIPTION
This test case check uploading image from file with short keystone token
expiration time.

Also tests was marked with testrail_id
