### PR TITLE
Added class for tests with network creation

### DIFF
--- a/mos_tests/conftest.py
+++ b/mos_tests/conftest.py
@@ -219,6 +219,7 @@ def os_conn_for_unittests(request, fuel_master_ip):
     fuel_client = get_fuel_client(fuel_master_ip)
     environment = fuel_client.get_last_created_cluster()
     request.cls.env = environment
+    request.cls.os_conn = get_os_conn(environment)
 
 
 @pytest.fixture

--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -297,7 +297,8 @@ class OpenStackActions(object):
     def delete_network(self, id):
         return self.neutron.delete_network(id)
 
-    def create_subnet(self, network_id, name, cidr, tenant_id=None):
+    def create_subnet(self, network_id, name, cidr, tenant_id=None,
+                      dns_nameservers=None):
         subnet = {
             "network_id": network_id,
             "ip_version": 4,
@@ -306,6 +307,8 @@ class OpenStackActions(object):
         }
         if tenant_id is not None:
             subnet['tenant_id'] = tenant_id
+        if dns_nameservers is not None:
+            subnet['dns_nameservers'] = dns_nameservers
         return self.neutron.create_subnet({'subnet': subnet})
 
     def delete_subnet(self, id):
@@ -465,7 +468,7 @@ class OpenStackActions(object):
             if router['name'] == 'router04':
                 continue
             try:
-                self.neutron.delete_router(router)
+                self.neutron.delete_router(router['id'])
             except NeutronClientException:
                 logger.info('the router {} is not deletable'.format(router))
 

--- a/mos_tests/murano/test_sanity.py
+++ b/mos_tests/murano/test_sanity.py
@@ -13,28 +13,95 @@
 #    under the License.
 
 import logging
+import os
+import shutil
+import tempfile
 import types
 import uuid
+import zipfile
 
 from muranodashboard.tests.functional import base
 from muranodashboard.tests.functional.config import config as cfg
 from muranodashboard.tests.functional import consts as c
+from muranodashboard.tests.functional import utils
 import pytest
 from selenium.webdriver.common import by
+from selenium.webdriver.support import expected_conditions as EC  # noqa
 from selenium.webdriver.support import ui
+from six.moves import configparser
+from six.moves.urllib import request
 from xvfbwrapper import Xvfb
 
+from mos_tests.functions import common
 from mos_tests import settings
 
 logger = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.undestructive
+
+apps_names = ['app_small', 'app_big']
+
 
 @pytest.yield_fixture(scope='class')
 def screen():
-    vdisplay = Xvfb()
+    vdisplay = Xvfb(width=1280, height=720)
     vdisplay.start()
     yield
     vdisplay.stop()
+
+
+@pytest.yield_fixture
+def package_size_limit(env):
+    def set_package_size_limit(node):
+        with node.ssh() as remote:
+            remote.check_call('service murano-api stop')
+            remote.check_call('mv /etc/murano/murano.conf '
+                              '/etc/murano/murano.conf.orig')
+            with remote.open('/etc/murano/murano.conf.orig') as f:
+                parser = configparser.RawConfigParser()
+                parser.readfp(f)
+                try:
+                    parser.set('packages_opts', 'package_size_limit', 2)
+                except configparser.NoSectionError:
+                    parser.add_section('packages_opts')
+                    parser.set('packages_opts', 'package_size_limit', 2)
+                with remote.open('/etc/murano/murano.conf', 'w') as new_f:
+                    parser.write(new_f)
+            remote.check_call('service murano-api start')
+
+    def reset_package_size_limit(node):
+        with node.ssh() as remote:
+            remote.check_call('service murano-api stop')
+            remote.check_call('mv /etc/murano/murano.conf.orig '
+                              '/etc/murano/murano.conf')
+            remote.check_call('service murano-api start')
+
+    controllers = env.get_nodes_by_role('controller')
+    for controller in controllers:
+        set_package_size_limit(controller)
+    yield
+    for controller in controllers:
+        reset_package_size_limit(controller)
+
+
+def prepare_zips():
+    def change_archive_size(archive_name, size):
+        file_name = os.path.join(os.path.split(archive_name)[0], 'file')
+        initial_size = os.path.getsize(archive_name)
+        with open(file_name, 'wb') as f:
+            f.seek(size * 1024 * 1024 - initial_size - 1)
+            f.write('\0')
+        with zipfile.ZipFile(archive_name, 'a') as archive:
+            archive.write(file_name)
+    tmp_dir = tempfile.mkdtemp()
+    manifest = os.path.join(c.PackageDir, 'manifest.yaml')
+    app_small = utils.compose_package(
+        apps_names[0], manifest, c.PackageDir, archive_dir=tmp_dir)
+    app_big = utils.compose_package(
+        apps_names[1], manifest, c.PackageDir, archive_dir=tmp_dir)
+    change_archive_size(app_small, 1.99)
+    change_archive_size(app_big, 2.01)
+    return [app_small, app_big]
 
 
 def murano_test_patch(cls):
@@ -147,7 +214,60 @@ class TestImportPackageWithDepencies(base.PackageTestCase):
 @pytest.mark.undestructive
 @pytest.mark.usefixtures('screen')
 @murano_test_patch
+class TestPackageSizeLimit(base.PackageTestCase):
+    """Test package size limit."""
+
+    def setUp(self):
+        super(TestPackageSizeLimit, self).setUp()
+        self.zips = prepare_zips()
+
+    def tearDown(self):
+        for pkg in self.murano_client.packages.list():
+            if pkg.name in apps_names:
+                self.murano_client.packages.delete(pkg.id)
+        shutil.rmtree((os.path.split(self.zips[0])[0]), ignore_errors=True)
+        super(TestPackageSizeLimit, self).tearDown()
+
+    @pytest.mark.usefixtures('package_size_limit')
+    def test_package_size_limit(self):
+        self.navigate_to('Manage')
+        self.go_to_submenu('Package Definitions')
+
+        # Upload package with allowed size
+        self.driver.find_element_by_id(c.UploadPackage).click()
+        el = self.driver.find_element_by_css_selector(
+            "input[name='upload-package']")
+        el.send_keys(self.zips[0])
+        self.driver.find_element_by_xpath(c.InputSubmit).click()
+        for el in self.driver.find_elements_by_class_name('alert'):
+            el.find_element_by_class_name('close').click()
+        self.driver.find_element_by_xpath(c.InputSubmit).click()
+        self.driver.find_element_by_xpath(c.InputSubmit).click()
+        self.wait_for_alert_message()
+        self.check_element_on_page(by.By.XPATH,
+                                   c.AppPackages.format(apps_names[0]))
+
+        # Upload package with not allowed size
+        self.driver.find_element_by_id(c.UploadPackage).click()
+        el = self.driver.find_element_by_css_selector(
+            "input[name='upload-package']")
+        el.send_keys(self.zips[1])
+        self.driver.find_element_by_xpath(c.InputSubmit).click()
+        error_message = ("Error: 400 Bad Request: Uploading file is too "
+                         "large. The limit is 2 Mb")
+        self.check_alert_message(error_message)
+        for el in self.driver.find_elements_by_class_name('alert'):
+            el.find_element_by_class_name('close').click()
+        self.check_element_not_on_page(by.By.XPATH,
+                                       c.AppPackages.format(apps_names[1]))
+
+
+@pytest.mark.requires_('firefox', 'xvfb-run')
+@pytest.mark.undestructive
+@pytest.mark.usefixtures('screen')
+@murano_test_patch
 class TestDeployEnvInNetwork(base.ApplicationTestCase):
+
     @classmethod
     def _create_network_with_subnet(cls, net_name, subnet_name,
                                     cidr=None):
@@ -183,23 +303,149 @@ class TestDeployEnvInNetwork(base.ApplicationTestCase):
             random_name = prefix + '_' + random_name
         return random_name
 
-    @classmethod
-    @pytest.fixture(scope='class')
-    def prepare(cls, os_conn_for_unittests):
-        cls.net_name = cls.gen_random_resource_name(prefix='net')
-        cls.subnet_name = cls.gen_random_resource_name(prefix='subnet')
-        cls.router_name = cls.gen_random_resource_name(prefix='router')
+    def _prepare(self, cidr):
+        self.net_name = self.gen_random_resource_name(prefix='net')
+        self.subnet_name = self.gen_random_resource_name(prefix='subnet')
+        self.router_name = self.gen_random_resource_name(prefix='router')
 
-        _, subnet = cls._create_network_with_subnet(
-            net_name=cls.net_name,
-            subnet_name=cls.subnet_name)
+        _, subnet = self._create_network_with_subnet(
+            net_name=self.net_name,
+            subnet_name=self.subnet_name,
+            cidr=cidr)
 
-        cls._create_router_between_nets(
-            router_name=cls.router_name,
-            ext_net=cls.os_conn.ext_network,
+        self._create_router_between_nets(
+            router_name=self.router_name,
+            ext_net=self.os_conn.ext_network,
             subnet=subnet)
 
+    @pytest.yield_fixture
+    def prepare_24(self, os_conn_for_unittests):
+        self._prepare(cidr='192.168.1.0/24')
+
+        yield
+
+        self.os_conn.cleanup_network()
+
+    @pytest.yield_fixture
+    def prepare_30(self, os_conn_for_unittests):
+        self._prepare(cidr='192.168.1.0/30')
+
+        yield
+
+        self.os_conn.cleanup_network()
+
     @classmethod
-    def tearDownClass(cls):
-        cls.os_conn.cleanup_network()
-        super(TestDeployEnvInNetwork, cls).tearDownClass()
+    @pytest.yield_fixture(scope='class')
+    def apache_image(cls):
+        image_properties = {
+            'murano_image_info': '{"type": "linux", "title": "testDeploy"}'
+        }
+        image = cls.glance.images.create(name="testDeploy",
+                                         disk_format='qcow2',
+                                         container_format='bare',
+                                         properties=image_properties)
+
+        image.update(data=request.urlopen(settings.MURANO_IMAGE_URL))
+        cls.apache_image_id = image.id
+
+        yield
+
+        cls.glance.images.delete(image.id)
+
+    @pytest.yield_fixture
+    def apache_package(self, apache_image):
+        app_name = 'Apache'
+        data = {"categories": ["Web"], "tags": ["tag"]}
+        files = {app_name: request.urlopen(settings.MURANO_PACKAGE_URL)}
+        package = self.murano_client.packages.create(data, files)
+        self.apache_id = package.id
+
+        yield
+
+        self.murano_client.packages.delete(package.id)
+
+    @pytest.fixture
+    def init(self):
+        self.env_name = self.gen_random_resource_name(prefix='env',
+                                                      reduce_by=4)
+        self.app_name = self.gen_random_resource_name(prefix='app',
+                                                      reduce_by=4)
+
+    def select_net(self, net_name):
+        locator = (by.By.XPATH,
+                   "//select[@name='net_config']"
+                   "/option[contains(text(),'{0}')]".format(net_name))
+        el = ui.WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located(locator))
+        el.click()
+
+    def add_component(self, app_id, env_id, app_name='TestApp'):
+        self.driver.find_element_by_xpath(
+            "//a[@id='services__action_AddApplication']").click()
+        self.driver.find_element_by_xpath(
+            ".//a[contains(@href, 'murano/catalog/add/"
+            "{app_id}/{env_id}')]".format(app_id=app_id, env_id=env_id)
+        ).click()
+        field_id = "{0}_0-name".format(app_id)
+        self.fill_field(by.By.ID, field_id, value=app_name)
+        self.driver.find_element_by_xpath(c.ButtonSubmit).click()
+
+        self.select_from_list('osImage', self.apache_image_id)
+        self.fill_field(by.By.NAME, '1-unitNamingPattern', value=self.env_name)
+        self.driver.find_element_by_xpath(c.InputSubmit).click()
+
+        self.driver.find_element_by_xpath(c.InputSubmit).click()
+        self.wait_for_alert_message()
+
+    def _deploy_env(self):
+        self.go_to_submenu('Environments')
+        self.driver.find_element_by_css_selector(
+            c.CreateEnvironment).click()
+        self.fill_field(by.By.ID, 'id_name', self.env_name)
+        self.select_net(net_name=self.net_name)
+        self.driver.find_element_by_id(c.ConfirmCreateEnvironment).click()
+        self.wait_for_alert_message()
+
+        env_id = self.murano_client.environments.find(name=self.env_name).id
+
+        self.add_component(app_id=self.apache_id, env_id=env_id,
+                           app_name=self.app_name)
+
+        self.driver.find_element_by_xpath(
+            "//button[@id='services__action_deploy_env']").click()
+
+        self.wait_for_alert_message()
+
+        common.wait(
+            lambda: self.murano_client.environments.get(
+                env_id).status != 'deploying',
+            timeout_seconds=5 * 60,
+            waiting_for='environment deployed')
+
+    @pytest.mark.usefixtures('init', 'apache_package', 'prepare_24')
+    def test_particular_network(self):
+
+        self._deploy_env()
+
+        env_id = self.murano_client.environments.find(name=self.env_name).id
+
+        self.assertEqual(self.murano_client.environments.get(env_id).status,
+                         'ready')
+
+        instance = [x for x in self.os_conn.nova.servers.findall()
+                    if self.env_name in x.name][0]
+        self.assertIn(self.net_name, instance.addresses.keys())
+
+    @pytest.mark.usefixtures('init', 'apache_package', 'prepare_30')
+    def test_particular_network_no_free_ip(self):
+
+        self._deploy_env()
+
+        self.driver.refresh()
+
+        status_el = self.driver.find_element_by_xpath(
+            "//table[@id='services']//td[.//*[contains(text(), '{0}')]]"
+            "/following-sibling::td[contains(@class, 'status_down')]".format(
+                self.app_name))
+
+        self.assertEqual(status_el.text, 'Deploy FAILURE')

--- a/mos_tests/settings.py
+++ b/mos_tests/settings.py
@@ -55,3 +55,5 @@ MURANO_PACKAGE_DEPS_NAMES = (
     'Kubernetes Cluster',
     'Kubernetes Pod',
 )
+MURANO_IMAGE_URL = 'http://storage.apps.openstack.org/images/debian-8-m-agent.qcow2'  # noqa
+MURANO_PACKAGE_URL = 'http://storage.apps.openstack.org/apps/io.murano.apps.apache.ApacheHttpServer.zip'  # noqa


### PR DESCRIPTION
Added TestDeployEnvInNetwork for test where we should add network, subnet,
router and some interfaces for them. It contains fixture for test
preparation and tearDown function for cleanup.
Modified function for routers deletion.
