### PR TITLE
Fix OpenStack CLI client parsing answer error

### DIFF
--- a/mos_tests/functions/os_cli.py
+++ b/mos_tests/functions/os_cli.py
@@ -49,12 +49,15 @@ class CLICLient(object):
         return os_execute(self.remote, command, fail_ok=fail_ok,
                           merge_stderr=merge_stderr)
 
-    def details(self, output):
-        return {x['Field']: x['Value'] for x in json.loads(output)}
-
 
 class OpenStack(CLICLient):
     command = 'openstack'
+
+    def details(self, output):
+        data = json.loads(output)
+        if isinstance(data, list):
+            data = {x['Field']: x['Value'] for x in data}
+        return data
 
     def project_create(self, name):
         output = self('project create', params='{} -f json'.format(name))


### PR DESCRIPTION
On new releases openstack client returns json, which converts to dict
(rather than list before). This patch checks type of decoded result and
transforms it to dict only if it necessary.
