### PR TITLE
fixed test_port_tags_immutable

### DIFF
--- a/mos_tests/neutron/python_tests/test_ovs_restart.py
+++ b/mos_tests/neutron/python_tests/test_ovs_restart.py
@@ -323,7 +323,7 @@ class TestOVSRestartTwoVms(OvsBase):
 
 
 @pytest.mark.check_env_('is_vlan')
-class TestPortTags(TestBase):
+class TestPortTags(OvsBase):
     """Check that port tags aren't change after ovs-agent restart"""
 
     def get_ports_tags_data(self, lines):


### PR DESCRIPTION
Fix for http://cz7776.bud.mirantis.net:8080/jenkins/job/9.0-NEUTRON_tests_generated_from_template/49/testReport/junit/mos_tests.neutron.python_tests.test_ovs_restart/TestPortTags/test_port_tags_immutable__542664__/
