### PR TITLE
fix of pid search is sh test

### DIFF
--- a/mos_tests/neutron/sh_tests/controller/test_Restart_child_metada-agent_with_kill_SIGHUP_command_580028.sh
+++ b/mos_tests/neutron/sh_tests/controller/test_Restart_child_metada-agent_with_kill_SIGHUP_command_580028.sh
@@ -6,7 +6,7 @@ screen -S META_SIG -d -m -- sh -c 'tailf /var/log/neutron/metadata-agent.log > l
 TEST_FAILED=0
 echo "Get a pid of a process for metada-agent"
 string1=$(pstree -up | grep metadat | awk '{print $1}')
-pid_before=$(echo $string1 | awk -F '+' '{print$2}' | awk -F '(' '{print$2}' | awk -F ')' '{print$1}')
+pid_before=$(echo $string1 | awk -F '---' '{print$2}' | awk -F '(' '{print$2}' | awk -F ')' '{print$1}')
 echo "Pid for child metada-agent process is "$pid_before
 echo "Kill a process with HUP "
 kill -SIGHUP $pid_before
@@ -15,7 +15,7 @@ echo "Check health agents"
 neutron agent-list | grep "Metadata agent"
 echo "Check status of a process after HUP restar"
 string1=$(pstree -up | grep metadat | awk '{print $1}')
-pid_after=$(echo $string1 | awk -F '+' '{print$2}' | awk -F '(' '{print$2}' | awk -F ')' '{print$1}')
+pid_after=$(echo $string1 | awk -F '---' '{print$2}' | awk -F '(' '{print$2}' | awk -F ')' '{print$1}')
 echo "PID after ="$pid_after
 if [ $pid_before = $pid_after ]; then
     echo "PIDs are equal"


### PR DESCRIPTION
Fix for the http://cz7776.bud.mirantis.net:8080/jenkins/job/9.0-NEUTRON_tests_generated_from_template/57/testReport/junit/mos_tests.neutron.sh_tests/test_sh/test_sh_controller_Restart_child_metada_agent_with_kill_SIGHUP_command__580028__/
