### PR TITLE
fixed sh test with duplicated log entires

### DIFF
--- a/mos_tests/neutron/sh_tests/controller/test_Restart_child_neutron-server_process_with_kill_SIGHUP_command_580024.sh
+++ b/mos_tests/neutron/sh_tests/controller/test_Restart_child_neutron-server_process_with_kill_SIGHUP_command_580024.sh
@@ -2,7 +2,7 @@
 
 . openrc
 
-screen -S SERVER_SIG -d -m -- sh -c 'tailf /var/log/neutron/server.log > log_server'
+screen -S SERVER_SIG -d -m -- sh -c 'tail -f /var/log/neutron/server.log | tee log_server'
 TEST_FAILED=0
 echo "Get a pid of a process for neutron-server"
 string1=$(pstree -up | grep neutron-server | awk '{print $1}')


### PR DESCRIPTION
Fix to avoid duplicated log entries like http://cz7776.bud.mirantis.net:8080/jenkins/job/9.0-NEUTRON_tests_generated_from_template/75/testReport/junit/mos_tests.neutron.sh_tests/test_sh/test_sh_controller_Restart_child_neutron_server_process_with_kill_SIGHUP_command__580024__/

During investigation was found that tailf sometimes add log entry about SIGHUP twice. However the original /var/log/neutron/server.log contains exactly one entry. tailf differs a bit from the 'tail -f'. But in this case it is not significant. The same problem might be seen on other sh tests as well. But it was seen only on this test so far. 
