### PR TITLE
Add test 'Boot Ironic instance with user-data'

### DIFF
--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -154,23 +154,16 @@ class OpenStackActions(object):
         if status == 'ERROR':
             raise Exception('Server {} status is error'.format(server.name))
 
-    def create_server(self, name, image_id=None, flavor=1, scenario='',
+    def create_server(self, name, image_id=None, flavor=1, userdata=None,
                       files=None, key_name=None, timeout=300,
                       wait_for_active=True, wait_for_avaliable=True, **kwargs):
-        try:
-            if scenario:
-                with open(scenario, "r+") as f:
-                    scenario = f.read()
-        except Exception as exc:
-            logger.info("Error opening file: %s" % exc)
-            raise Exception()
 
         if image_id is None:
             image_id = self._get_cirros_image().id
         srv = self.nova.servers.create(name=name,
                                        image=image_id,
                                        flavor=flavor,
-                                       userdata=scenario,
+                                       userdata=userdata,
                                        files=files,
                                        key_name=key_name,
                                        **kwargs)

--- a/mos_tests/ironic/manage_instances_test.py
+++ b/mos_tests/ironic/manage_instances_test.py
@@ -15,6 +15,7 @@
 import pytest
 
 from mos_tests.functions import common
+from mos_tests import settings
 
 
 @pytest.fixture
@@ -121,3 +122,26 @@ def test_instance_rebuild(env, ironic, os_conn, ironic_node, ubuntu_image,
     server = os_conn.rebuild_server(instance, ubuntu_image.id)
     common.wait(lambda: os_conn.nova.servers.get(server).status == 'ACTIVE',
                 timeout_seconds=60 * 10, waiting_for="instance is active")
+
+
+@pytest.mark.check_env_('has_ironic_conductor')
+@pytest.mark.need_devops
+@pytest.mark.testrail_id('631916')
+def test_boot_instance_with_user_data(ubuntu_image, flavors, keypair,
+                                      ironic, ironic_nodes, os_conn, env):
+    """Boot Ubuntu14-based virtual-bare-metal instance with user-data
+
+    Scenario:
+        1. Boot ironic instance with user data file user_data.sh
+        2. Check that user_data.sh is present on instance
+        3. Ping 8.8.8.8 from instance
+    """
+    instance = ironic.boot_instance(image=ubuntu_image,
+                                    flavor=flavors[0],
+                                    keypair=keypair,
+                                    userdata='touch /userdata_result')
+
+    with os_conn.ssh_to_instance(env, instance, vm_keypair=keypair,
+                                 username='ubuntu') as remote:
+        remote.check_call('ls /userdata_result')
+        remote.check_call('ping -c1 {}'.format(settings.PUBLIC_TEST_IP))


### PR DESCRIPTION
This test boot Ubuntu14-based virtual-bare-metal instance with
user-data and checks that user-data.sh is present in home folder.
