### PR TITLE
Add tests for concurrently/consequently boot of 2 instances

### DIFF
--- a/mos_tests/ironic/conftest.py
+++ b/mos_tests/ironic/conftest.py
@@ -138,7 +138,7 @@ def image_file():
     image_file.unlink(image_file.name)
 
 
-@pytest.yield_fixture(params=['create', 'delete'])
+@pytest.yield_fixture(params=[['create', 'delete']])
 def ubuntu_image(request, os_conn, image_file):
     actions = request.param
     image_name = 'ironic_trusty'

--- a/mos_tests/ironic/manage_instances_test.py
+++ b/mos_tests/ironic/manage_instances_test.py
@@ -18,10 +18,13 @@ from mos_tests.functions import common
 
 
 @pytest.fixture
-def instance(ubuntu_image, flavors, keypair, ironic_nodes, ironic):
+def instance(ubuntu_image, flavors, keypair, ironic_nodes, ironic, request):
+    instance_count = getattr(request, 'param', 1)
+    kwargs = {'min_count': instance_count}
     instance = ironic.boot_instance(image=ubuntu_image,
                                     flavor=flavors[0],
-                                    keypair=keypair)
+                                    keypair=keypair,
+                                    **kwargs)
     return instance
 
 
@@ -121,3 +124,48 @@ def test_instance_rebuild(env, ironic, os_conn, ironic_node, ubuntu_image,
     server = os_conn.rebuild_server(instance, ubuntu_image.id)
     common.wait(lambda: os_conn.nova.servers.get(server).status == 'ACTIVE',
                 timeout_seconds=60 * 10, waiting_for="instance is active")
+
+
+@pytest.mark.check_env_('has_ironic_conductor')
+@pytest.mark.parametrize('ironic_nodes', [2], indirect=['ironic_nodes'])
+@pytest.mark.parametrize('instance', [2], indirect=['instance'])
+@pytest.mark.testrail_id('631915')
+def test_boot_nodes_concurrently(env, keypair, os_conn, instance):
+    """Check boot several bare-metal nodes concurrently
+
+    Scenario:
+        1. Boot several baremetal instances at the same time
+        2. Check that instances statuses are ACTIVE
+        3. Check that both baremetal instances are available via ssh
+    """
+    servers = filter(lambda srv: srv.name.startswith('ironic-server-'),
+                     os_conn.nova.servers.list())
+    for server in servers:
+        with os_conn.ssh_to_instance(env, server, vm_keypair=keypair,
+                                     username='ubuntu') as remote:
+            remote.check_call('uname')
+
+
+@pytest.mark.check_env_('has_ironic_conductor')
+@pytest.mark.parametrize('ironic_nodes', [2], indirect=['ironic_nodes'])
+@pytest.mark.testrail_id('631913')
+def test_boot_nodes_consequently(env, os_conn, ubuntu_image, flavors, keypair,
+                                 instance):
+    """Check boot several bare-metal nodes consequently
+
+    Scenario:
+        1. Boot 1st baremetal instance
+        2. Check that 1st instance is in ACTIVE status
+        3. Boot 2nd baremetal instance
+        4. Check that 2nd instance is in ACTIVE status
+        5. Check that both baremetal instances are available via ssh
+    """
+    baremetal_net = os_conn.nova.networks.find(label='baremetal')
+    srv2 = os_conn.create_server('ironic-server-2', image_id=ubuntu_image.id,
+                                 flavor=flavors[0].id, key_name=keypair.name,
+                                 nics=[{'net-id': baremetal_net.id}],
+                                 timeout=60 * 10)
+    for server in [srv2, instance]:
+        with os_conn.ssh_to_instance(env, server, vm_keypair=keypair,
+                                     username='ubuntu') as remote:
+            remote.check_call('uname')


### PR DESCRIPTION
Added tests for concurrently/consequently boot of 2 instances
Fix an issue with ubuntu_image fixture
