### PR TITLE
Remove patching proxy on controllers

### DIFF
--- a/mos_tests/environment/os_actions.py
+++ b/mos_tests/environment/os_actions.py
@@ -66,10 +66,10 @@ class OpenStackActions(object):
                                 auth_url=auth_url,
                                 tenant_name=tenant)
 
-        self.session = session.Session(auth=auth, verify=self.path_to_cert,
-                                       session=proxy_session)
+        self.session = session.Session(auth=auth, verify=self.path_to_cert)
 
         self.keystone = KeystoneClient(session=self.session)
+        self.keystone.management_url = auth_url
 
         self.nova = nova_client.Client(version=2, session=self.session)
 

--- a/mos_tests/neutron/python_tests/test_dvr.py
+++ b/mos_tests/neutron/python_tests/test_dvr.py
@@ -16,10 +16,10 @@ from datetime import datetime
 import logging
 import time
 
+from keystoneclient.auth.identity.v2 import Password as KeystonePassword
 from neutronclient.common.exceptions import NeutronClientException
 import neutronclient.v2_0.client as neutronclient
 import pytest
-from tempfile import NamedTemporaryFile
 
 from mos_tests.environment.devops_client import DevopsClient
 from mos_tests.functions.common import wait
@@ -1151,7 +1151,7 @@ class TestDVRTypeChange(TestDVRBase):
         self.check_vm_connectivity()
 
     @pytest.mark.testrail_id('542758')
-    def test_create_dvr_by_no_admin_user(self):
+    def test_create_dvr_by_no_admin_user(self, openstack_client):
         """Create distributed router with member user
 
         Steps:
@@ -1165,49 +1165,18 @@ class TestDVRTypeChange(TestDVRBase):
             8.  Log in as admin user
             9.  Check that parameter Distributed is true
         """
-
-        # Find the admin tenant
-        admin_role = self.os_conn.keystone.roles.find(name='admin')
-        admin_tenant = None
-        for tenant in self.os_conn.keystone.tenants.list():
-            if admin_role in tenant.manager.role_manager.list():
-                admin_tenant = tenant
-                break
-        assert admin_tenant, "Can't find the tenant with admin role"
-
-        # Create new user
-        # Member role is used by default
         username = 'test_dvr'
         userpass = 'test_dvr'
-        # But at first check if the same user exist
-        # try to find it and delete
-        try:
-            user = self.os_conn.keystone.users.find(name=username)
-            self.os_conn.keystone.users.delete(user)
-        except Exception as e:
-            logger.info('Tried to clean up user with result: {}'.format(e))
-        # Actual user creation is here
-        user = self.os_conn.keystone.users.create(name=username,
-                                                  password=userpass,
-                                                  tenant_id=admin_tenant.id)
+        tenant = 'admin'
 
-        # Find the certificate for the current env
-        # and log in with new user in new netron client
-        cert = self.env.certificate
-        path_to_cert = None
-        if cert:
-            with NamedTemporaryFile(prefix="fuel_cert_", suffix=".pem",
-                                    delete=False) as f:
-                f.write(cert)
-            path_to_cert = f.name
+        openstack_client.user_create(username, userpass, project=tenant)
 
-        auth_url = self.os_conn.session.auth.auth_url
-        tenant_name = self.os_conn.session.auth.tenant_name
-        neutron = neutronclient.Client(username=username,
-                                       password=userpass,
-                                       tenant_name=tenant_name,
-                                       auth_url=auth_url,
-                                       ca_cert=path_to_cert)
+        auth = KeystonePassword(username=username,
+                                password=userpass,
+                                auth_url=self.os_conn.session.auth.auth_url,
+                                tenant_name=tenant)
+
+        neutron = neutronclient.Client(auth=auth, session=self.os_conn.session)
 
         # Try to create router with explicit distributed True value
         # by user with member role but in admin tenant

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@ git+git://github.com/openstack/fuel-devops.git@2.9.16
 paramiko>=1.16.0
 pytest
 pytest-xdist
-python-glanceclient==1.1.0
-python-keystoneclient>1.3.3,<2.0.0
-python-novaclient>=2.27.0,<3.0.0
+python-glanceclient>=2.0.0
+python-keystoneclient>=2.3.0
+python-novaclient>=3.3.0
 python-cinderclient>=1.0.5
-python-neutronclient>=2.0,<4.0.0
-python-heatclient>=0.2.12
+python-neutronclient>=4.0.0
+python-heatclient>=1.0.0
 python-fuelclient
 requests>=2.2.0
 ndg-httpsclient>=0.4.0


### PR DESCRIPTION
On tests with restart controller it's hard to manage session with proxy.
Now keystone works with Public URL. For managing roles, users, project
use OpenStack CLI client.
