### PR TITLE
RabbitMQ and OSLO: Start RPC server/client and restart one/all controllers

### DIFF
--- a/mos_tests/rabbitmq_oslo/conftest.py
+++ b/mos_tests/rabbitmq_oslo/conftest.py
@@ -17,6 +17,7 @@ import pytest
 
 @pytest.yield_fixture
 def fixt_open_5000_port_on_nodes(env):
+    """Required to be able to send GET request from non management IP"""
     for node in env.get_all_nodes():
         with node.ssh() as remote:
             cmd = 'iptables -A INPUT -p tcp --dport 5000 -j ACCEPT'
@@ -27,3 +28,13 @@ def fixt_open_5000_port_on_nodes(env):
             # delete rule
             cmd = 'iptables -D INPUT -p tcp --dport 5000 -j ACCEPT'
             remote.check_call(cmd)
+
+
+@pytest.yield_fixture
+def fixt_kill_rpc_server_client(env):
+    """Stop oslo_msg_check_server AND oslo_msg_check_client after test"""
+    yield
+    for node in env.get_all_nodes():
+        with node.ssh() as remote:
+            cmd = 'pkill -f oslo_msg_check_'
+            remote.execute(cmd)

--- a/mos_tests/rabbitmq_oslo/conftest.py
+++ b/mos_tests/rabbitmq_oslo/conftest.py
@@ -1,0 +1,29 @@
+#    Copyright 2016 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import pytest
+
+
+@pytest.yield_fixture
+def fixt_open_5000_port_on_nodes(env):
+    for node in env.get_all_nodes():
+        with node.ssh() as remote:
+            cmd = 'iptables -A INPUT -p tcp --dport 5000 -j ACCEPT'
+            remote.check_call(cmd)
+    yield
+    for node in env.get_all_nodes():
+        with node.ssh() as remote:
+            # delete rule
+            cmd = 'iptables -D INPUT -p tcp --dport 5000 -j ACCEPT'
+            remote.check_call(cmd)

--- a/mos_tests/rabbitmq_oslo/test_restarts.py
+++ b/mos_tests/rabbitmq_oslo/test_restarts.py
@@ -65,7 +65,7 @@ def install_oslomessagingchecktool(remote, **kwargs):
     cmd2 = ("cd {repo_path} && "
             "dpkg -i {pkg} || "
             "apt-get -f install -y").format(**kwargs)
-    logger.debug('Install "oslo.messaging-check-tool" on controller %s.' %
+    logger.debug('Install "oslo.messaging-check-tool" on %s.' %
                  remote.host)
     remote.check_call(cmd1)
     remote.check_call(cmd2)
@@ -92,7 +92,7 @@ def configure_oslomessagingchecktool(remote, ctrl_ips, nova_user, nova_pass,
         parser.set('oslo_messaging_rabbit', 'rabbit_password', nova_pass)
         # Dump to cfg file to screen
         parser.write(sys.stdout)
-        logger.debug('Write [{0}] config file to controller {1}.'.format(
+        logger.debug('Write [{0}] config file to {1}.'.format(
             cfg_file_path, remote.host))
         # Write to new cfg file
         with remote.open(cfg_file_path, 'w') as new_f:
@@ -158,6 +158,9 @@ def restart_rabbitmq_serv(env, remote=None, sleep=10):
         logger.debug('Restart RabbinMQ server on ALL controllers one-by-one')
         for controller in controllers:
             with controller.ssh() as remote:
+                # Before and after restart check that rabbit is ok.
+                # Useful if we as restarting all controllers.
+                wait_for_rabbit_running_nodes(remote, len(controllers))
                 remote.check_call(restart_cmd)
                 wait_for_rabbit_running_nodes(remote, len(controllers))
     else:
@@ -449,7 +452,7 @@ def test_load_messages_and_restart_prim_nonprim_ctrlr(restart_ctrlr, env):
 @pytest.mark.check_env_('is_ha', 'has_1_or_more_computes')
 @pytest.mark.testrail_id('838289', params={'restart_ctrlr': 'one'})
 @pytest.mark.testrail_id('838290', params={'restart_ctrlr': 'all'})
-@pytest.mark.parametrize('restart_ctrlr', ['one', 'all'])
+@pytest.mark.parametrize('restart_ctrlr', ['one', 'all', 'prim', 'non_prim'])
 def test_start_rpc_srv_client_restart_rabbit_one_all_ctrllr(
         env, restart_ctrlr, fixt_open_5000_port_on_nodes,
         fixt_kill_rpc_server_client):
@@ -476,8 +479,14 @@ def test_start_rpc_srv_client_restart_rabbit_one_all_ctrllr(
     timeout_min = 2  # (minutes) time to wait for RPC server/client start
 
     controllers = env.get_nodes_by_role('controller')
-    controller = random.choice(controllers)
     compute = random.choice(env.get_nodes_by_role('compute'))
+
+    if restart_ctrlr == 'prim':
+        controller = env.primary_controller
+    elif restart_ctrlr == 'non_prim':
+        controller = random.choice(env.non_primary_controllers)
+    else:
+        controller = random.choice(controllers)
 
     # Get management IPs of all controllers
     ctrl_ips = get_mngmnt_ip_of_ctrllrs(env)
@@ -512,7 +521,7 @@ def test_start_rpc_srv_client_restart_rabbit_one_all_ctrllr(
 
     # Restart RabbinMQ server on one/all controller(s)
     with controller.ssh() as remote:
-        if restart_ctrlr == 'one':
+        if restart_ctrlr in ('one', 'prim', 'non_prim'):
             restart_rabbitmq_serv(env, remote=remote)
         elif restart_ctrlr == 'all':
             restart_rabbitmq_serv(env, remote=None)


### PR DESCRIPTION
QA-2290 - Start RabbitMQ RPC server and client and restart RabbitMQ on one controller
QA-2291 - Start RabbitMQ RPC server and client and restart RabbitMQ on all controllers one-by-one
QA-2293 - Start RabbitMQ RPC server and client and restart non-primary controller
QA-2294 - Start RabbitMQ RPC server and client and restart primary controller
