### PR TITLE
RabbitMQ and OSLO: Start RPC server/client and modify IPTables

### DIFF
--- a/mos_tests/rabbitmq_oslo/conftest.py
+++ b/mos_tests/rabbitmq_oslo/conftest.py
@@ -46,55 +46,41 @@ def fixt_kill_rpc_server_client(env):
             remote.execute(cmd)
 
 
+@pytest.fixture
+def controller(env):
+    return random.choice(env.get_nodes_by_role('controller'))
+
+
 @pytest.yield_fixture
-def fixt_iptables_drop_reject(env, request):
-    """Choose one controller and apply IPTables rules"""
-    i_am_chosen_mark = '/tmp/i_am_chosen_mark.txt'
+def patch_iptables(controller, request):
+    """Apply IPTables rules"""
+
+    def add_ports(tmpl):
+        ports = [4369, 5672, 5673, 25672]
+        return ' '.join(map(lambda portnum: tmpl.format(portnum=portnum),
+                            ports))
 
     if request.param == 'drop':
-        table_modif = (
-            'iptables -I INPUT -p tcp -m tcp --dport 4369  -j DROP ; '
-            'iptables -I INPUT -p tcp -m tcp --dport 25672 -j DROP ; '
-            'iptables -I INPUT -p tcp -m tcp --dport 5672  -j DROP ; '
-            'iptables -I INPUT -p tcp -m tcp --dport 5673  -j DROP ; ')
-        table_modif_del = (
-            'iptables -D INPUT -p tcp -m tcp --dport 4369  -j DROP ; '
-            'iptables -D INPUT -p tcp -m tcp --dport 25672 -j DROP ; '
-            'iptables -D INPUT -p tcp -m tcp --dport 5672  -j DROP ; '
-            'iptables -D INPUT -p tcp -m tcp --dport 5673  -j DROP ; ')
+        tbl_modif = add_ports(
+            'iptables -I INPUT -p tcp -m tcp --dport {portnum} -j DROP ;')
+        tbl_modif_del = add_ports(
+            'iptables -D INPUT -p tcp -m tcp --dport {portnum} -j DROP ;')
     elif request.param == 'reject':
-        table_modif = (
-            'iptables -I INPUT -p tcp -m tcp --dport 4369'
-            ' -j REJECT --reject-with icmp-host-prohibited ; '
-            'iptables -I INPUT -p tcp -m tcp --dport 25672'
-            ' -j REJECT --reject-with icmp-host-prohibited ; '
-            'iptables -I INPUT -p tcp -m tcp --dport 5672'
-            ' -j REJECT --reject-with icmp-host-prohibited ; '
-            'iptables -I INPUT -p tcp -m tcp --dport 5673'
-            ' -j REJECT --reject-with icmp-host-prohibited ; ')
-        table_modif_del = (
-            'iptables -D INPUT -p tcp -m tcp --dport 4369'
-            ' -j REJECT --reject-with icmp-host-prohibited ; '
-            'iptables -D INPUT -p tcp -m tcp --dport 25672'
-            ' -j REJECT --reject-with icmp-host-prohibited ; '
-            'iptables -D INPUT -p tcp -m tcp --dport 5672'
-            ' -j REJECT --reject-with icmp-host-prohibited ; '
-            'iptables -D INPUT -p tcp -m tcp --dport 5673'
-            ' -j REJECT --reject-with icmp-host-prohibited ; ')
+        tbl_modif = add_ports(
+            'iptables -I INPUT -p tcp -m tcp --dport {portnum} -j REJECT'
+            ' --reject-with icmp-host-prohibited ;')
+        tbl_modif_del = add_ports(
+            'iptables -D INPUT -p tcp -m tcp --dport {portnum} -j REJECT'
+            ' --reject-with icmp-host-prohibited ;')
     else:
         raise ValueError("Does'n know such param [{0}]!".format(request.param))
 
-    controller = random.choice(env.get_nodes_by_role('controller'))
     logger.debug('Applying IPTables rules [{0}] to {1}'.format(
         request.param, controller.data['ip']))
     with controller.ssh() as remote:
-        # execute iptables DROP command
-        remote.check_call(table_modif)
-        # mark this controller
-        with remote.open(i_am_chosen_mark, 'w') as f:
-            f.write("Hello? Is it me you're looking for?\n")
+        remote.check_call(tbl_modif)
     yield
+
     # revert changes
     with controller.ssh() as remote:
-        remote.rm_rf(i_am_chosen_mark)
-        remote.check_call(table_modif_del)
+        remote.check_call(tbl_modif_del)

--- a/mos_tests/rabbitmq_oslo/conftest.py
+++ b/mos_tests/rabbitmq_oslo/conftest.py
@@ -12,7 +12,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import logging
+import random
+
 import pytest
+
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.yield_fixture
@@ -38,3 +44,57 @@ def fixt_kill_rpc_server_client(env):
         with node.ssh() as remote:
             cmd = 'pkill -f oslo_msg_check_'
             remote.execute(cmd)
+
+
+@pytest.yield_fixture
+def fixt_iptables_drop_reject(env, request):
+    """Choose one controller and apply IPTables rules"""
+    i_am_chosen_mark = '/tmp/i_am_chosen_mark.txt'
+
+    if request.param == 'drop':
+        table_modif = (
+            'iptables -I INPUT -p tcp -m tcp --dport 4369  -j DROP ; '
+            'iptables -I INPUT -p tcp -m tcp --dport 25672 -j DROP ; '
+            'iptables -I INPUT -p tcp -m tcp --dport 5672  -j DROP ; '
+            'iptables -I INPUT -p tcp -m tcp --dport 5673  -j DROP ; ')
+        table_modif_del = (
+            'iptables -D INPUT -p tcp -m tcp --dport 4369  -j DROP ; '
+            'iptables -D INPUT -p tcp -m tcp --dport 25672 -j DROP ; '
+            'iptables -D INPUT -p tcp -m tcp --dport 5672  -j DROP ; '
+            'iptables -D INPUT -p tcp -m tcp --dport 5673  -j DROP ; ')
+    elif request.param == 'reject':
+        table_modif = (
+            'iptables -I INPUT -p tcp -m tcp --dport 4369'
+            ' -j REJECT --reject-with icmp-host-prohibited ; '
+            'iptables -I INPUT -p tcp -m tcp --dport 25672'
+            ' -j REJECT --reject-with icmp-host-prohibited ; '
+            'iptables -I INPUT -p tcp -m tcp --dport 5672'
+            ' -j REJECT --reject-with icmp-host-prohibited ; '
+            'iptables -I INPUT -p tcp -m tcp --dport 5673'
+            ' -j REJECT --reject-with icmp-host-prohibited ; ')
+        table_modif_del = (
+            'iptables -D INPUT -p tcp -m tcp --dport 4369'
+            ' -j REJECT --reject-with icmp-host-prohibited ; '
+            'iptables -D INPUT -p tcp -m tcp --dport 25672'
+            ' -j REJECT --reject-with icmp-host-prohibited ; '
+            'iptables -D INPUT -p tcp -m tcp --dport 5672'
+            ' -j REJECT --reject-with icmp-host-prohibited ; '
+            'iptables -D INPUT -p tcp -m tcp --dport 5673'
+            ' -j REJECT --reject-with icmp-host-prohibited ; ')
+    else:
+        raise ValueError("Does'n know such param [{0}]!".format(request.param))
+
+    controller = random.choice(env.get_nodes_by_role('controller'))
+    logger.debug('Applying IPTables rules [{0}] to {1}'.format(
+        request.param, controller.data['ip']))
+    with controller.ssh() as remote:
+        # execute iptables DROP command
+        remote.check_call(table_modif)
+        # mark this controller
+        with remote.open(i_am_chosen_mark, 'w') as f:
+            f.write("Hello? Is it me you're looking for?\n")
+    yield
+    # revert changes
+    with controller.ssh() as remote:
+        remote.rm_rf(i_am_chosen_mark)
+        remote.check_call(table_modif_del)

--- a/mos_tests/rabbitmq_oslo/test_restarts.py
+++ b/mos_tests/rabbitmq_oslo/test_restarts.py
@@ -615,3 +615,75 @@ def test_start_rpc_srv_client_shutdown_eth_on_all(
     # host srv -> client: Check GET after controller(s) restart
     logger.debug('GET: [host server] -> [{0}]'.format(rpc_client_ip))
     assert get_http_code(rpc_client_ip) == exp_resp
+
+
+@pytest.mark.undestructive
+@pytest.mark.check_env_('is_ha', 'has_1_or_more_computes')
+@pytest.mark.testrail_id(
+    '838294', params={'fixt_iptables_drop_reject': 'drop'})
+@pytest.mark.testrail_id(
+    '838295', params={'fixt_iptables_drop_reject': 'reject'})
+@pytest.mark.parametrize('fixt_iptables_drop_reject', ['drop', 'reject'],
+                         indirect=['fixt_iptables_drop_reject'])
+def test_start_rpc_srv_client_iptables_modify(
+        env, fixt_open_5000_port_on_nodes, fixt_kill_rpc_server_client,
+        fixt_iptables_drop_reject):
+    """Tests:
+    Start RabbitMQ RPC server and client and apply IPTABLES DROP rules
+        for RabbitMQ ports on one controller.
+
+    Actions:
+    1. Apply IPTables Drop OR Reject rules to controller where
+        'oslo_msg_check_server' will be launched;
+    2. To be able to use port 5000 from any node open it in IPTables;
+    3. Install 'oslo.messaging-check-tool' on controller and compute;
+    4. Prepare config file for both nodes above;
+    5. Run 'oslo_msg_check_client' on compute node;
+    6. Run 'oslo_msg_check_server' on controller node (remember point 1);
+    7. Send GET curl request from host server to 'oslo_msg_check_client'
+        located on compute node and check that response will '200';
+    8. Remove all modifications of rules from IPTables and kill serv/client.
+    """
+    exp_resp = 200   # expected response code from curl from RPC client
+    timeout_min = 2  # (minutes) time to wait for RPC server/client start
+    i_am_chosen_mark = '/tmp/i_am_chosen_mark.txt'
+
+    controllers = env.get_nodes_by_role('controller')
+    compute = random.choice(env.get_nodes_by_role('compute'))
+    # find controller, marked with fixture
+    for controller in controllers:
+        with controller.ssh() as remote:
+            if remote.isfile(i_am_chosen_mark):
+                break
+
+    # Get management IPs of all controllers
+    ctrl_ips = get_mngmnt_ip_of_ctrllrs(env)
+
+    # Install and configure tool on controller and compute
+    for node in (controller, compute):
+        with node.ssh() as remote:
+            kwargs = vars_config(remote)
+            install_oslomessagingchecktool(remote, **kwargs)
+            configure_oslomessagingchecktool(
+                remote, ctrl_ips, kwargs['nova_user'], kwargs['nova_pass'],
+                kwargs['cfg_file_path'], kwargs['sample_cfg_file_path'])
+
+    # Client: Run 'oslo_msg_check_client' on compute
+    with compute.ssh() as remote:
+        rpc_client_ip = rabbit_rpc_client_start(
+            remote, kwargs['cfg_file_path'])
+    # Server: Run 'oslo_msg_check_server' on controller
+    with controller.ssh() as remote:
+        rabbit_rpc_server_start(remote, kwargs['cfg_file_path'])
+
+    # host srv -> client: Check GET before any actions
+    logger.debug('GET: [host server] -> [{0}]'.format(rpc_client_ip))
+    # need to wait for server/client start
+    wait(lambda: get_http_code(rpc_client_ip) == exp_resp,
+         timeout_seconds=60 * timeout_min,
+         sleep_seconds=20,
+         waiting_for='RPC server/client to start')
+
+    # host srv -> client: Check GET after controller(s) restart
+    logger.debug('GET: [host server] -> [{0}]'.format(rpc_client_ip))
+    assert get_http_code(rpc_client_ip) == exp_resp


### PR DESCRIPTION
QA-2295 - Start RabbitMQ RPC server and client and apply IPTABLES DROP rules for RabbitMQ ports on one controller
QA-2296 - Start RabbitMQ RPC server and client and apply IPTABLES REJECT rules for RabbitMQ ports on one controller
