### PR TITLE
Maintenance: Glance security: Added tests to check image direct url

### DIFF
--- a/mos_tests/glance/conftest.py
+++ b/mos_tests/glance/conftest.py
@@ -165,3 +165,38 @@ def enable_multiple_locations_glance(env):
     for controller in controllers:
         reset_show_multiple_locations(controller)
     wait_glance_alive()
+
+
+@pytest.yield_fixture
+def enable_image_direct_url_glance(env):
+    """Change show_image_direct_url to True"""
+
+    def set_show_image_direct_url(node):
+        with node.ssh() as remote:
+            remote.check_call('mv /etc/glance/glance-api.conf '
+                              '/etc/glance/glance-api.conf.orig')
+            remote.check_call("cat /etc/glance/glance-api.conf.orig | sed "
+                              "'s/show_image_direct_url = False/"
+                              "show_image_direct_url = True/g' > "
+                              "/etc/glance/glance-api.conf")
+            remote.check_call('service glance-api restart')
+
+    def reset_show_image_direct_url(node):
+        with node.ssh() as remote:
+            remote.check_call('mv /etc/glance/glance-api.conf.orig '
+                              '/etc/glance/glance-api.conf')
+            remote.check_call('service glance-api restart')
+
+    def wait_glance_alive():
+        common.wait(lambda: common.get_os_conn(env), timeout_seconds=60 * 3,
+                    waiting_for='glance available',
+                    expected_exceptions=Exception)
+
+    controllers = env.get_nodes_by_role('controller')
+    for controller in controllers:
+        set_show_image_direct_url(controller)
+    wait_glance_alive()
+    yield
+    for controller in controllers:
+        reset_show_image_direct_url(controller)
+    wait_glance_alive()


### PR DESCRIPTION
- test_image_direct_url_false checks absence of 'direct_url' property for image by default (only for Swift)
- test_image_direct_url_true checks that if to set show_image_direct_url = True, value of 'direct_url' property doesn't contain glance credentials (tenant:user:password) (only for Swift)
