### PR TITLE
Maintenance: Glance security: Added tests to check image direct url

### DIFF
--- a/mos_tests/glance/conftest.py
+++ b/mos_tests/glance/conftest.py
@@ -161,3 +161,38 @@ def enable_multiple_locations_glance(env):
     for controller in controllers:
         reset_show_multiple_locations(controller)
     wait_glance_alive()
+
+
+@pytest.yield_fixture
+def enable_image_direct_url_glance(env):
+    """Change show_image_direct_url to True"""
+
+    def set_show_image_direct_url(node):
+        with node.ssh() as remote:
+            remote.check_call('mv /etc/glance/glance-api.conf '
+                              '/etc/glance/glance-api.conf.orig')
+            remote.check_call("cat /etc/glance/glance-api.conf.orig | sed "
+                              "'s/show_image_direct_url = False/"
+                              "show_image_direct_url = True/g' > "
+                              "/etc/glance/glance-api.conf")
+            remote.check_call('service glance-api restart')
+
+    def reset_show_image_direct_url(node):
+        with node.ssh() as remote:
+            remote.check_call('mv /etc/glance/glance-api.conf.orig '
+                              '/etc/glance/glance-api.conf')
+            remote.check_call('service glance-api restart')
+
+    def wait_glance_alive():
+        common.wait(lambda: common.get_os_conn(env), timeout_seconds=60 * 3,
+                    waiting_for='glance available',
+                    expected_exceptions=Exception)
+
+    controllers = env.get_nodes_by_role('controller')
+    for controller in controllers:
+        set_show_image_direct_url(controller)
+    wait_glance_alive()
+    yield
+    for controller in controllers:
+        reset_show_image_direct_url(controller)
+    wait_glance_alive()

--- a/mos_tests/glance/security_test.py
+++ b/mos_tests/glance/security_test.py
@@ -24,7 +24,7 @@ from mos_tests import settings
 
 class TestGlanceSecurity(TestBase):
 
-    @pytest.mark.testrail_id('674709')
+    @pytest.mark.testrail_id('836638')
     @pytest.mark.usefixtures('enable_multiple_locations_glance')
     @pytest.mark.parametrize('glance', [2], indirect=['glance'])
     def test_remove_last_image_location(self, glance, suffix):
@@ -44,7 +44,7 @@ class TestGlanceSecurity(TestBase):
         name = "Test_{0}".format(suffix[:6])
         url_1 = settings.GLANCE_IMAGE_URL
         url_2 = ('http://download.cirros-cloud.net/0.3.1/'
-                'cirros-0.3.1-x86_64-disk.img')
+                 'cirros-0.3.1-x86_64-disk.img')
         metadata = {}
 
         image = self.os_conn.glance.images.create(name=name,
@@ -75,6 +75,67 @@ class TestGlanceSecurity(TestBase):
         image = self.os_conn.glance.images.get(image.id)
         assert len(image.locations) == 1
         assert image.status == 'active'
+
+        self.os_conn.glance.images.delete(image.id)
+        images_id = [i.id for i in self.os_conn.glance.images.list()]
+        assert image.id not in images_id
+
+    @pytest.mark.testrail_id('836636')
+    @pytest.mark.parametrize('glance', [2], indirect=['glance'])
+    def test_image_direct_url_false(self, glance, image_file_remote, suffix):
+        """Check absence of 'direct_url' property for glance image by default
+        for Swift storage
+
+        Scenario:
+            1. Create image from `image_file`
+            2. Check that image status is `active`
+            3. Check that image doesn't have property 'direct_url'
+            4. Delete image
+            5. Check that image deleted
+        """
+        name = "Test_{0}".format(suffix[:6])
+        image = self.os_conn.glance.images.create(name=name,
+                                                  disk_format='qcow2',
+                                                  container_format='bare')
+        self.os_conn.glance.images.upload(image.id, image_file_remote)
+
+        image = self.os_conn.glance.images.get(image.id)
+        assert image.status == 'active'
+        assert 'direct_url' not in image.keys()
+
+        self.os_conn.glance.images.delete(image.id)
+        images_id = [i.id for i in self.os_conn.glance.images.list()]
+        assert image.id not in images_id
+
+    @pytest.mark.testrail_id('843822')
+    @pytest.mark.usefixtures('enable_image_direct_url_glance')
+    @pytest.mark.parametrize('glance', [2], indirect=['glance'])
+    def test_image_direct_url_true(self, glance, image_file_remote, suffix):
+        """Check that value of 'direct_url' property doesn't contain glance
+        credentials (tenant:user:password) in case of show_image_direct_url =
+        True for Swift storage
+
+        Scenario:
+            1. Set show_image_direct_url = True in glance-api.conf on all
+            controllers and restart glance-api service on all controllers
+            2. Create image from `image_file`
+            3. Check that image status is `active`
+            4. Check that value of image property 'direct_url' has format
+            'swift+config://ref1/glance/image_id'
+            5. Delete image
+            6. Check that image deleted
+        """
+        name = "Test_{0}".format(suffix[:6])
+        image = self.os_conn.glance.images.create(name=name,
+                                                  disk_format='qcow2',
+                                                  container_format='bare')
+        self.os_conn.glance.images.upload(image.id, image_file_remote)
+
+        image = self.os_conn.glance.images.get(image.id)
+        assert image.status == 'active'
+        expected_direct_url_value = ('swift+config://ref1/glance/{image_id}'
+                                     .format(image_id=image.id))
+        assert image.direct_url == expected_direct_url_value
 
         self.os_conn.glance.images.delete(image.id)
         images_id = [i.id for i in self.os_conn.glance.images.list()]

--- a/mos_tests/neutron/python_tests/test_dvr.py
+++ b/mos_tests/neutron/python_tests/test_dvr.py
@@ -1269,6 +1269,7 @@ class TestDVRRegression(TestDVRBase):
                                              self.logs_path))['exit_code']
                 assert res == 0
 
+    @pytest.mark.testrail_id('843828')
     @pytest.mark.usefixtures('prepare_neutron_logs')
     def test_add_router_interface_with_port_id(self):
         """Add router interface with port_id parameter


### PR DESCRIPTION
- test_image_direct_url_false checks absence of 'direct_url' property for image by default (only for Swift)
- test_image_direct_url_true checks that if to set show_image_direct_url = True, value of 'direct_url' property doesn't contain glance credentials (tenant:user:password) (only for Swift)
