### PR TITLE
Add QoS tests for 3 VM in 2 net with router

### DIFF
--- a/mos_tests/neutron/python_tests/test_qos.py
+++ b/mos_tests/neutron/python_tests/test_qos.py
@@ -23,7 +23,11 @@ from mos_tests.neutron.python_tests import base
 from mos_tests import settings
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.undestructive
+
 BOOT_MARKER = 'INSTANCE BOOT COMPLETED'
+TCP_PORT = 5002
+UDP_PORT = 5003
 
 
 def wait_instances_to_boot(os_conn, instances):
@@ -36,61 +40,144 @@ def wait_instances_to_boot(os_conn, instances):
         waiting_for="instances to be ready")
 
 
+def delete_instances(os_conn, instances):
+    instances_ids = [x.id for x in instances]
+
+    # Stop instances (to prevent error during deletion)
+    for instance_id in instances_ids:
+        os_conn.nova.servers.stop(instance_id)
+
+    def isnstances_shutdowned():
+        instances = [x
+                       for x in os_conn.nova.servers.list()
+                       if x.id in instances_ids]
+        if any([x.status == 'ERROR' for x in instances]):
+            raise Exception(
+                'Some server(s) became to ERROR state after stop')
+        return all([x.status == 'SHUTOFF' for x in instances])
+
+    common.wait(isnstances_shutdowned, timeout_seconds=10 * 60)
+
+    # Delete instances
+    for instance_id in instances_ids:
+        os_conn.nova.servers.delete(instance_id)
+
+    def instances_deleted():
+        not_deleted = [x
+                       for x in os_conn.nova.servers.list()
+                       if x.id in instances_ids]
+        if len(not_deleted) == 0:
+            return True
+        if any([x.status == 'ERROR' for x in not_deleted]):
+            raise Exception(
+                'Some server(s) became to ERROR state after deletion')
+
+    common.wait(instances_deleted, timeout_seconds=2 * 60)
+
+
+def delete_ports_policy(os_conn):
+    for port in os_conn.neutron.list_ports()['ports']:
+        policy_id = port['qos_policy_id']
+        if policy_id is not None:
+            os_conn.neutron.update_port(port['id'],
+                                        {'port': {'qos_policy_id': None}})
+            os_conn.delete_qos_policy(policy_id)
+
+
+@pytest.yield_fixture(scope='module')
+def iperf_image_id(os_conn):
+    logger.info('Creating ubuntu image')
+    image = os_conn.glance.images.create(name="image_ubuntu",
+                                         disk_format='qcow2',
+                                         container_format='bare')
+    with file_cache.get_file(settings.UBUNTU_QCOW2_URL) as f:
+        os_conn.glance.images.upload(image.id, f)
+
+    logger.info('Ubuntu image created')
+    yield image.id
+    os_conn.glance.images.delete(image.id)
+
+
+@pytest.yield_fixture(scope='module')
+def instance_keypair(os_conn):
+    keypair = os_conn.create_key(key_name='instancekey')
+    yield keypair
+    os_conn.delete_key(key_name='instancekey')
+
+
+@pytest.yield_fixture(scope='module')
+def security_group(os_conn):
+    security_group = os_conn.create_sec_group_for_ssh()
+    yield security_group
+    os_conn.nova.security_groups.delete(security_group.id)
+
+
 @pytest.mark.check_env_('is_qos_enabled')
 class TestQoSBase(base.TestBase):
-    @pytest.fixture(autouse=True)
-    def variables(self, os_conn):
-        self.zone = os_conn.nova.availability_zones.find(zoneName="nova")
-        self.security_group = os_conn.create_sec_group_for_ssh()
-        self.instance_keypair = os_conn.create_key(key_name='instancekey')
-        self.os_conn = os_conn
+    @classmethod
+    @pytest.fixture(scope='class', autouse=True)
+    def variables(cls, os_conn, iperf_image_id, instance_keypair,
+                  security_group):
+        cls.zone = os_conn.nova.availability_zones.find(zoneName="nova")
+        cls.security_group = security_group
+        cls.instance_keypair = instance_keypair
+        cls.os_conn = os_conn
+        cls.image_id = iperf_image_id
 
-    @pytest.fixture
-    def iperf_image_id(self, os_conn):
-        logger.info('Creating ubuntu image')
-        image = os_conn.glance.images.create(name="image_ubuntu",
-                                             disk_format='qcow2',
-                                             container_format='bare')
-        with file_cache.get_file(settings.UBUNTU_QCOW2_URL) as f:
-            os_conn.glance.images.upload(image.id, f)
-
-        logger.info('Ubuntu image created')
-        self.image_id = image.id
-        return self.image_id
-
-    @pytest.fixture
-    def networks(self, variables, os_conn):
-        self.net = os_conn.create_network(name='net01')
-        self.subnet = os_conn.create_subnet(
-            network_id=self.net['network']['id'],
-            name='net01__subnet',
-            cidr='10.0.0.0/24')
+    @classmethod
+    @pytest.yield_fixture(scope='class')
+    def network(cls, variables, os_conn):
+        cls.net = os_conn.create_network(name='net01')
+        cls.subnet = os_conn.create_subnet(network_id=cls.net['network']['id'],
+                                           name='net01__subnet',
+                                           cidr='10.0.0.0/24')
         ext_net = os_conn.ext_network
-        self.router = os_conn.create_router(name='router01')
-        os_conn.router_gateway_add(router_id=self.router['router']['id'],
+        cls.router = os_conn.create_router(name='router01')
+        os_conn.router_gateway_add(router_id=cls.router['router']['id'],
                                    network_id=ext_net['id'])
 
-        os_conn.router_interface_add(router_id=self.router['router']['id'],
-                                     subnet_id=self.subnet['subnet']['id'])
+        os_conn.router_interface_add(router_id=cls.router['router']['id'],
+                                     subnet_id=cls.subnet['subnet']['id'])
+        yield
+        os_conn.delete_router(cls.router['router']['id'])
+        os_conn.delete_network(cls.net['network']['id'])
 
-    def boot_iperf_instance(self, name, compute_node, net, udp=False):
-        userdata = (
-            '#!/bin/bash -v\n'
-            'apt-get install -yq iperf\n'
-            'echo "{marker}"\n'
-            'iperf {udp_flag} -s -p 5002 <&- > /tmp/iperf.log 2>&1'
-        ).format(marker=BOOT_MARKER,
-                 udp_flag='-u' if udp else '')  # yapf: disable
+    @pytest.yield_fixture
+    def clean_net_policy(self, os_conn):
+        yield
+        net = os_conn.neutron.show_network(self.net['network']['id'])
+        policy_id = net['network']['qos_policy_id']
+        if policy_id is not None:
+            os_conn.neutron.update_network(
+                net['network']['id'], {'network': {'qos_policy_id': None}})
+            os_conn.delete_qos_policy(policy_id)
 
-        return self.os_conn.create_server(
+    @pytest.yield_fixture
+    def clean_port_policy(self, os_conn):
+        yield
+        delete_ports_policy(os_conn)
+
+    @classmethod
+    def boot_iperf_instance(cls, name, compute_node, net, udp=False):
+        userdata = '\n'.join([
+            '#!/bin/bash -v',
+            'apt-get install -yq iperf',
+            'iperf -s -p {tcp_port} <&- > /tmp/iperf.log 2>&1 &',
+            'iperf -u -s -p {udp_port} <&- > /tmp/iperf_udp.log 2>&1 &',
+            'echo "{marker}"',
+        ]).format(marker=BOOT_MARKER,
+                  tcp_port=TCP_PORT,
+                  udp_port=UDP_PORT)
+
+        return cls.os_conn.create_server(
             name=name,
-            availability_zone='{}:{}'.format(self.zone.zoneName, compute_node),
-            image_id=self.image_id,
+            availability_zone='{}:{}'.format(cls.zone.zoneName, compute_node),
+            image_id=cls.image_id,
             flavor=2,
             userdata=userdata,
-            key_name=self.instance_keypair.name,
+            key_name=cls.instance_keypair.name,
             nics=[{'net-id': net['network']['id']}],
-            security_groups=[self.security_group.id],
+            security_groups=[cls.security_group.id],
             wait_for_active=False,
             wait_for_avaliable=False)
 
@@ -99,9 +186,9 @@ class TestQoSBase(base.TestBase):
                          server_ip,
                          time=80,
                          interval=20,
-                         port=5002,
                          udp=False):
         interval = min(interval, time)
+        port = UDP_PORT if udp else TCP_PORT
         if udp:
             cmd = ('iperf -u -c {ip} -p {port} -x CDMS -y C -t {time} '
                    '-i {interval} --bandwidth 10M')
@@ -117,8 +204,10 @@ class TestQoSBase(base.TestBase):
             # Show only server report
             stdout = result['stdout'][-1:]
         else:
+            stdout = result['stdout']
             # Exclude summary
-            stdout = result['stdout'][:-1]
+            if len(stdout) > 1:
+                stdout = stdout[:-1]
             # Strip first result, because it almost always too high
             if len(stdout) > 1:
                 stdout = stdout[1:]
@@ -126,8 +215,13 @@ class TestQoSBase(base.TestBase):
         for line in reader:
             yield line
 
-    def check_iperf_bandwidth(self, client, server, limit, **kwargs):
-        server_ip = self.os_conn.get_nova_instance_ips(server)['fixed']
+    def check_iperf_bandwidth(self,
+                              client,
+                              server,
+                              limit,
+                              ip_type='fixed',
+                              **kwargs):
+        server_ip = self.os_conn.get_nova_instance_ips(server)[ip_type]
         with self.os_conn.ssh_to_instance(
                 self.env,
                 client,
@@ -135,25 +229,28 @@ class TestQoSBase(base.TestBase):
                 vm_keypair=self.instance_keypair) as remote:
             for line in self.get_iperf_result(remote, server_ip, **kwargs):
                 bandwidth = int(line[8])
-                assert (limit / 2) < bandwidth <= limit
+                assert (limit * 0.8) < bandwidth <= limit * 1.05
 
 
 @pytest.mark.check_env_('has_1_or_more_computes')
 class TestSingleCompute(TestQoSBase):
-    @pytest.fixture
-    def instances(self, variables, networks, iperf_image_id, os_conn):
+    @classmethod
+    @pytest.yield_fixture(scope='class')
+    def instances(cls, variables, network, iperf_image_id, os_conn):
         instances = []
-        compute_node = self.zone.hosts.keys()[0]
+        compute_node = cls.zone.hosts.keys()[0]
         for i in range(2):
-            instance = self.boot_iperf_instance(name='server%02d' % i,
-                                                compute_node=compute_node,
-                                                net=self.net)
+            instance = cls.boot_iperf_instance(name='server%02d' % i,
+                                               compute_node=compute_node,
+                                               net=cls.net)
             instances.append(instance)
         wait_instances_to_boot(os_conn, instances)
-        return instances
+        yield instances
+        delete_instances(os_conn, instances)
 
     @pytest.mark.testrail_id('838298')
-    def test_traffic_restriction_with_max_burst(self, instances, os_conn):
+    def test_traffic_restriction_with_max_burst(self, instances, os_conn,
+                                                clean_net_policy):
         """Check traffic restriction between vm for different max-burst
         parameter
 
@@ -176,9 +273,9 @@ class TestSingleCompute(TestQoSBase):
             9. Check that egress traffic on vm1 must be eq
                 --max-kbps + --max-burst
         """
-        self.policy = os_conn.create_qos_policy('policy_1')
-        self.rule = os_conn.neutron.create_bandwidth_limit_rule(
-            self.policy['policy']['id'], {
+        policy = os_conn.create_qos_policy('policy_1')
+        rule = os_conn.neutron.create_bandwidth_limit_rule(
+            policy['policy']['id'], {
                 'bandwidth_limit_rule': {
                     'max_kbps': 4000,
                     'max_burst_kbps': 300,
@@ -186,14 +283,13 @@ class TestSingleCompute(TestQoSBase):
             })
         os_conn.neutron.update_network(
             self.net['network']['id'],
-            {'network': {'qos_policy_id': self.policy['policy']['id']}})
+            {'network': {'qos_policy_id': policy['policy']['id']}})
 
         client, server = instances
         self.check_iperf_bandwidth(client, server, (4000 + 300) * 1024)
 
         self.os_conn.neutron.update_bandwidth_limit_rule(
-            self.rule['bandwidth_limit_rule']['id'],
-            self.policy['policy']['id'], {
+            rule['bandwidth_limit_rule']['id'], policy['policy']['id'], {
                 'bandwidth_limit_rule': {
                     'max_kbps': 6000,
                     'max_burst_kbps': 500,
@@ -203,21 +299,26 @@ class TestSingleCompute(TestQoSBase):
 
 
 @pytest.mark.check_env_('has_2_or_more_computes')
-class TestTraficBetweenComputes(TestQoSBase):
-    @pytest.fixture
-    def instances(self, variables, networks, iperf_image_id, os_conn):
+class DifferentComputesInstancesMixin(object):
+    @classmethod
+    @pytest.yield_fixture(scope='class')
+    def instances(cls, variables, network, iperf_image_id, os_conn):
         instances = []
-        compute_nodes = self.zone.hosts.keys()[:2]
+        compute_nodes = cls.zone.hosts.keys()[:2]
         for i in range(2):
-            instance = self.boot_iperf_instance(name='server%02d' % i,
-                                                compute_node=compute_nodes[i],
-                                                net=self.net)
+            instance = cls.boot_iperf_instance(name='server%02d' % i,
+                                               compute_node=compute_nodes[i],
+                                               net=cls.net)
             instances.append(instance)
         wait_instances_to_boot(os_conn, instances)
-        return instances
+        yield instances
+        delete_instances(os_conn, instances)
 
+
+class TestTraficBetweenComputes(DifferentComputesInstancesMixin, TestQoSBase):
     @pytest.mark.testrail_id('838303')
-    def test_qos_between_vms_on_different_computes(self, instances, os_conn):
+    def test_qos_between_vms_on_different_computes(self, instances, os_conn,
+                                                   clean_port_policy):
         """Check different traffic restriction for vms between two vms
         in one net on different compute node
 
@@ -249,13 +350,13 @@ class TestTraficBetweenComputes(TestQoSBase):
             self.check_iperf_bandwidth(instance1,
                                        instance2,
                                        limit=4000 * 1024,
-                                       time=10)
+                                       time=20)
 
         with pytest.raises(AssertionError):
             self.check_iperf_bandwidth(instance2,
                                        instance1,
                                        limit=4000 * 1024,
-                                       time=10)
+                                       time=20)
 
         instance1_ip = os_conn.get_nova_instance_ips(instance1)['fixed']
         port1 = os_conn.get_port_by_fixed_ip(instance1_ip)
@@ -287,71 +388,9 @@ class TestTraficBetweenComputes(TestQoSBase):
 
         self.check_iperf_bandwidth(instance2, instance1, limit=4000 * 1024)
 
-    @pytest.mark.testrail_id('838306')
-    def test_create_net_with_policy(self, os_conn, variables, iperf_image_id):
-        """Check traffic restriction for net between two vms in one net
-        on different compute nodes (create net with policy)
-
-        Scenario:
-            1. Create new policy: neutron qos-policy-create bw-limiter
-            2. Create new rule:
-                neutron qos-bandwidth-limit-rule-create rule-id bw-limiter \
-                --max-kbps 3000
-            3. Create net01 with parameter --qos-policy bw-limiter , subnet
-            4. Create router01, set gateway and add interface to net01
-            5. Boot ubuntu vm1 in net01 on compute-1
-            6. Boot ubuntu vm2 in net01 on compute-2
-            7. Start iperf between vm1 and vm2
-            8. Look on the traffic with nload on vm port on compute-1
-            9. Check in nload that traffic changed properly for both vms
-            10. Delete rule:
-                neutron qos-bandwidth-limit-rule-delete rule-id bw-limiter
-            11. Check in nload that traffic changed properly for both vms
-        """
-        policy = os_conn.create_qos_policy('policy_1')
-        rule = os_conn.neutron.create_bandwidth_limit_rule(
-            policy['policy']['id'], {
-                'bandwidth_limit_rule': {
-                    'max_kbps': 3000,
-                }
-            })
-        net = os_conn.create_network(name='net01',
-                                     qos_policy_id=policy['policy']['id'])
-        subnet = os_conn.create_subnet(network_id=net['network']['id'],
-                                       name='net01__subnet',
-                                       cidr='10.0.0.0/24')
-
-        ext_net = os_conn.ext_network
-        router = os_conn.create_router(name='router01')
-        os_conn.router_gateway_add(router_id=router['router']['id'],
-                                   network_id=ext_net['id'])
-
-        os_conn.router_interface_add(router_id=router['router']['id'],
-                                     subnet_id=subnet['subnet']['id'])
-
-        instances = []
-        compute_nodes = self.zone.hosts.keys()[:2]
-        for i in range(2):
-            instance = self.boot_iperf_instance(name='server%02d' % i,
-                                                compute_node=compute_nodes[i],
-                                                net=net)
-            instances.append(instance)
-        wait_instances_to_boot(os_conn, instances)
-
-        self.check_iperf_bandwidth(instances[0],
-                                   instances[1],
-                                   limit=3000 * 1024)
-
-        os_conn.neutron.delete_bandwidth_limit_rule(
-            rule['bandwidth_limit_rule']['id'], policy['policy']['id'])
-
-        with pytest.raises(AssertionError):
-            self.check_iperf_bandwidth(instances[0],
-                                       instances[1],
-                                       limit=3000 * 1024)
-
     @pytest.mark.testrail_id('838310')
-    def test_restrictions_on_net_and_vm(self, instances, os_conn):
+    def test_restrictions_on_net_and_vm(self, instances, os_conn,
+                                        clean_port_policy, clean_net_policy):
         """Check traffic restriction between vms if there are different
         restrictions in the net and vm
 
@@ -424,29 +463,94 @@ class TestTraficBetweenComputes(TestQoSBase):
         self.check_iperf_bandwidth(instance1, instance2, limit=6000 * 1024)
 
 
+class TestPolicyWithNetCreate(DifferentComputesInstancesMixin, TestQoSBase):
+    @classmethod
+    @pytest.yield_fixture(scope='class')
+    def network(cls, variables, os_conn):
+        cls.policy = os_conn.create_qos_policy('policy_1')
+        cls.rule = os_conn.neutron.create_bandwidth_limit_rule(
+            cls.policy['policy']['id'], {
+                'bandwidth_limit_rule': {
+                    'max_kbps': 3000,
+                }
+            })
+        cls.net = os_conn.create_network(
+            name='net01',
+            qos_policy_id=cls.policy['policy']['id'])
+        cls.subnet = os_conn.create_subnet(network_id=cls.net['network']['id'],
+                                           name='net01__subnet',
+                                           cidr='10.0.0.0/24')
+        ext_net = os_conn.ext_network
+        cls.router = os_conn.create_router(name='router01')
+        os_conn.router_gateway_add(router_id=cls.router['router']['id'],
+                                   network_id=ext_net['id'])
+
+        os_conn.router_interface_add(router_id=cls.router['router']['id'],
+                                     subnet_id=cls.subnet['subnet']['id'])
+        yield
+        os_conn.delete_router(cls.router['router']['id'])
+        os_conn.delete_network(cls.net['network']['id'])
+        os_conn.delete_qos_policy(cls.policy['policy']['id'])
+
+    @pytest.mark.testrail_id('838306')
+    def test_create_net_with_policy(self, os_conn, instances):
+        """Check traffic restriction for net between two vms in one net
+        on different compute nodes (create net with policy)
+
+        Scenario:
+            1. Create new policy: neutron qos-policy-create bw-limiter
+            2. Create new rule:
+                neutron qos-bandwidth-limit-rule-create rule-id bw-limiter \
+                --max-kbps 3000
+            3. Create net01 with parameter --qos-policy bw-limiter , subnet
+            4. Create router01, set gateway and add interface to net01
+            5. Boot ubuntu vm1 in net01 on compute-1
+            6. Boot ubuntu vm2 in net01 on compute-2
+            7. Start iperf between vm1 and vm2
+            8. Look on the traffic with nload on vm port on compute-1
+            9. Check in nload that traffic changed properly for both vms
+            10. Delete rule:
+                neutron qos-bandwidth-limit-rule-delete rule-id bw-limiter
+            11. Check in nload that traffic changed properly for both vms
+        """
+
+        self.check_iperf_bandwidth(instances[0],
+                                   instances[1],
+                                   limit=3000 * 1024)
+
+        os_conn.neutron.delete_bandwidth_limit_rule(
+            self.rule['bandwidth_limit_rule']['id'],
+            self.policy['policy']['id'])
+
+        with pytest.raises(AssertionError):
+            self.check_iperf_bandwidth(instances[0],
+                                       instances[1],
+                                       limit=3000 * 1024,
+                                       time=20)
+
+
 @pytest.mark.check_env_('has_2_or_more_computes')
-class TestTraficBetween3Instances(TestQoSBase):
-    @pytest.fixture
-    def instances(self, request, variables, networks, iperf_image_id, os_conn):
-        udp = request.param or False
+class TestTraficBetween3InstancesInOneNet(TestQoSBase):
+    @classmethod
+    @pytest.yield_fixture(scope='class')
+    def instances(cls, variables, network, iperf_image_id, os_conn):
         instances = []
-        compute_nodes = self.zone.hosts.keys()[:2]
+        compute_nodes = cls.zone.hosts.keys()[:2]
         compute_nodes.insert(0, compute_nodes[0])
         for i, node in enumerate(compute_nodes):
-            instance = self.boot_iperf_instance(name='server%02d' % i,
-                                                compute_node=node,
-                                                net=self.net,
-                                                udp=udp)
+            instance = cls.boot_iperf_instance(name='server%02d' % i,
+                                               compute_node=node,
+                                               net=cls.net)
             instances.append(instance)
         wait_instances_to_boot(os_conn, instances)
-        return instances
+        yield instances
+        delete_instances(os_conn, instances)
 
     @pytest.mark.testrail_id('838299', udp=False)
     @pytest.mark.testrail_id('839064', udp=True)
-    @pytest.mark.parametrize('instances, udp',
-                             [(False, False), (True, True)],
-                             indirect=['instances'])
-    def test_traffic_for_one_vm_and_2_another(self, instances, os_conn, udp):
+    @pytest.mark.parametrize('udp', [True, False], ids=['udp', 'tcp'])
+    def test_traffic_for_one_vm_and_2_another(self, instances, os_conn, udp,
+                                              clean_port_policy):
         """Check traffic restriction for one vm between two vms in one net
 
         Scenario:
@@ -509,3 +613,156 @@ class TestTraficBetween3Instances(TestQoSBase):
                                    instance3,
                                    limit=3000 * 1024,
                                    udp=udp)
+
+
+@pytest.mark.incremental
+@pytest.mark.check_env_('has_2_or_more_computes')
+class TestTraficBetween3InstancesInDifferentNet(TestQoSBase):
+    @classmethod
+    @pytest.yield_fixture(scope='class')
+    def network2(cls, variables, os_conn, network):
+        net = os_conn.create_network(name='net02')
+        subnet = os_conn.create_subnet(network_id=net['network']['id'],
+                                       name='net02__subnet',
+                                       cidr='10.0.1.0/24')
+
+        os_conn.router_interface_add(router_id=cls.router['router']['id'],
+                                     subnet_id=subnet['subnet']['id'])
+        yield net
+        os_conn.delete_network(net['network']['id'])
+
+    @classmethod
+    @pytest.yield_fixture(scope='class')
+    def instances(cls, variables, network, iperf_image_id, os_conn, network2):
+        instances = []
+        compute_nodes = cls.zone.hosts.keys()[:2]
+        compute_nodes.insert(0, compute_nodes[0])
+        networks = [cls.net, network2, network2]
+        for i, (node, net) in enumerate(zip(compute_nodes, networks)):
+            instance = cls.boot_iperf_instance(name='server%02d' % i,
+                                               compute_node=node,
+                                               net=net)
+            instances.append(instance)
+        wait_instances_to_boot(os_conn, instances)
+        for instance in instances:
+            os_conn.assign_floating_ip(instance)
+        yield instances
+        delete_instances(os_conn, instances)
+
+    @classmethod
+    @pytest.yield_fixture(scope='class')
+    def clean_port_policy(cls, os_conn):
+        yield
+        delete_ports_policy(os_conn)
+
+    @pytest.mark.testrail_id('838301')
+    def test_traffic_with_different_nets(self, instances, os_conn):
+        """Check traffic restriction for one vm between two vms in different
+        nets with router between them
+
+        Scenario:
+            1. Create net01, subnet
+            2. Create net02, subnet
+            3. Create router01, set gateway and add interfaces to net01 and
+                to net02
+            4. Boot ubuntu vm1 in net01 on compute-1
+            5. Boot ubuntu vm2 in net02 on compute-1
+            6. Boot ubuntu vm3 in net02 on compute-2
+            7. Associate floatings to all vms
+            8. Start iperf between vm1 and vm2 by floating
+            9. Look on the traffic with nload on vm port on compute-1
+            10. Start iperf between vm1 and vm3
+            11. Look on the traffic with nload on vm port on compute-1
+            12. Create new policy: neutron qos-policy-create bw-limiter
+            13. Create new rule:
+                neutron qos-bandwidth-limit-rule-create rule-id bw-limiter \
+                --max-kbps 3000
+            14. Find neutron port for vm1: neutron port-list | grep <vm1 ip>
+            15. Update port with new policy:
+                neutron port-update your-port-id --qos-policy bw-limiter
+            16. Check in nload that traffic changed properly
+        """
+        instance1, instance2, instance3 = instances
+
+        with pytest.raises(AssertionError):
+            self.check_iperf_bandwidth(instance1,
+                                       instance2,
+                                       limit=3000 * 1024,
+                                       ip_type='floating',
+                                       time=20)
+
+        with pytest.raises(AssertionError):
+            self.check_iperf_bandwidth(instance1,
+                                       instance3,
+                                       limit=3000 * 1024,
+                                       time=20)
+
+        # Create policy for port
+        instance1_ip = os_conn.get_nova_instance_ips(instance1)['fixed']
+        port1 = os_conn.get_port_by_fixed_ip(instance1_ip)
+        self.__class__.policy = os_conn.create_qos_policy('policy_1')
+        self.__class__.rule = os_conn.neutron.create_bandwidth_limit_rule(
+            self.__class__.policy['policy']['id'], {
+                'bandwidth_limit_rule': {
+                    'max_kbps': 3000,
+                }
+            })
+
+        os_conn.neutron.update_port(
+            port1['id'],
+            {'port': {'qos_policy_id': self.__class__.policy['policy']['id']}})
+
+        self.check_iperf_bandwidth(instance1,
+                                   instance2,
+                                   limit=3000 * 1024,
+                                   ip_type='floating')
+
+        self.check_iperf_bandwidth(instance1, instance3, limit=3000 * 1024)
+
+    @pytest.mark.testrail_id('838302')
+    def test_traffic_with_different_nets_after_rule_update(self, instances,
+                                                           os_conn):
+        """Check traffic restriction for one vm between two vms in one net
+        on one compute node during updating rule
+
+        Scenario:
+            1. Create net01, subnet
+            2. Create net02, subnet
+            3. Create router01, set gateway and add interfaces to net01 and
+                to net02
+            4. Boot ubuntu vm1 in net01 on compute-1
+            5. Boot ubuntu vm2 in net02 on compute-1
+            6. Boot ubuntu vm3 in net02 on compute-2
+            7. Associate floatings to all vms
+            8. Start iperf between vm1 and vm2 by floating
+            9. Look on the traffic with nload on vm port on compute-1
+            10. Start iperf between vm1 and vm3
+            11. Look on the traffic with nload on vm port on compute-1
+            12. Create new policy: neutron qos-policy-create bw-limiter
+            13. Create new rule:
+                neutron qos-bandwidth-limit-rule-create rule-id bw-limiter \
+                --max-kbps 3000
+            14. Find neutron port for vm1: neutron port-list | grep <vm1 ip>
+            15. Update port with new policy:
+                neutron port-update your-port-id --qos-policy bw-limiter
+            16. Check in nload that traffic changed properly
+            17. Update rule:
+                neutron qos-bandwidth-limit-rule-update rule-id bw-limiter \
+                --max-kbps 1000
+            18. Check in nload that traffic is changed properly
+        """
+        instance1, instance2, instance3 = instances
+
+        os_conn.neutron.update_bandwidth_limit_rule(
+            self.__class__.rule['bandwidth_limit_rule']['id'],
+            self.__class__.policy['policy']['id'], {
+                'bandwidth_limit_rule': {
+                    'max_kbps': 1000,
+                }
+            })
+        self.check_iperf_bandwidth(instance1,
+                                   instance2,
+                                   limit=1000 * 1024,
+                                   ip_type='floating')
+
+        self.check_iperf_bandwidth(instance1, instance3, limit=1000 * 1024)


### PR DESCRIPTION
This tests check:
- traffic restriction for one vm between two vms in different nets with
  router between them
- traffic restriction for one vm between two vms in one net on one
  compute node during updating rule

QA-2468
QA-2469
