### PR TITLE
Maintenance: Added test_check_port_binding_after_restart_node

### DIFF
--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -308,8 +308,17 @@ class TestBase(object):
             result['stderr'])
         assert not result['exit_code'], err_msg
 
-    def create_networks(self, net_number, router, net_list, inst_keypair,
-                        security_group):
+    def create_delete_number_of_instances(self, net_number, router, net_list,
+                                          inst_keypair, security_group):
+        """Create X number of networks, create and delete instance on it.
+
+        :param net_number: number of networks to create
+        :param router: router to external network
+        :param net_list: list of existed networks
+        :param inst_keypair: private keys to connect to instance
+        :param security_group: security group that instance is related to
+        :returns: -
+        """
         tenant = self.os_conn.neutron.get_quotas_tenant()
         tenant_id = tenant['tenant']['tenant_id']
         self.os_conn.neutron.update_quota(tenant_id, {'quota':

--- a/mos_tests/neutron/python_tests/base.py
+++ b/mos_tests/neutron/python_tests/base.py
@@ -307,3 +307,26 @@ class TestBase(object):
         err_msg = 'Failed to start the udhcpc on vm std_err: {}'.format(
             result['stderr'])
         assert not result['exit_code'], err_msg
+
+    def create_networks(self, net_number, router, net_list, inst_keypair,
+                        security_group):
+        tenant = self.os_conn.neutron.get_quotas_tenant()
+        tenant_id = tenant['tenant']['tenant_id']
+        self.os_conn.neutron.update_quota(tenant_id, {'quota':
+                                                      {'network': 50,
+                                                       'router': 50,
+                                                       'subnet': 50,
+                                                       'port': 150}})
+        for x in range(net_number):
+            net_id = self.os_conn.add_net(router['id'])
+            net_list.append(net_id)
+            logger.info('Total networks created at the moment {}'.format(
+                        len(net_list)))
+            srv = self.os_conn.create_server(
+                name='instanceNo{}'.format(x),
+                key_name=inst_keypair.name,
+                security_groups=[security_group.name],
+                nics=[{'net-id': net_id}],
+                wait_for_avaliable=False)
+            logger.info('Delete the server {}'.format(srv.name))
+            self.os_conn.nova.servers.delete(srv)

--- a/mos_tests/neutron/python_tests/test_dhcp_agent.py
+++ b/mos_tests/neutron/python_tests/test_dhcp_agent.py
@@ -79,8 +79,9 @@ class TestDHCPAgent(TestBase):
         # According to the test requirements 50 networks should be created
         # However during implementation found that only about 34 nets
         # can be created for one tenant. Need to clarify that situation.
-        self.create_networks(29, self.router, self.networks,
-                             self.instance_keypair, self.security_group)
+        self.create_delete_number_of_instances(29, self.router, self.networks,
+                                               self.instance_keypair,
+                                               self.security_group)
 
         # Count networks for each dhcp agent
         # Each agent should contain networks
@@ -289,8 +290,9 @@ class TestDHCPAgent(TestBase):
         # According to the test requirements 50 networks should be created
         # However during implementation found that only about 34 nets
         # can be created for one tenant. Need to clarify that situation.
-        self.create_networks(29, self.router, self.networks,
-                             self.instance_keypair, self.security_group)
+        self.create_delete_number_of_instances(29, self.router, self.networks,
+                                               self.instance_keypair,
+                                               self.security_group)
 
         # Get amount of DHCP agents for the net9
         net_id = self.networks[8]

--- a/mos_tests/neutron/python_tests/test_restarts.py
+++ b/mos_tests/neutron/python_tests/test_restarts.py
@@ -464,11 +464,11 @@ class TestRestarts(TestBase):
         # According to the test requirements 50 networks should be created
         # However during implementation found that only about 34 nets
         # can be created for one tenant. Need to clarify that situation.
-        self.create_networks(5, self.router, self.networks,
+        self.create_networks(29, self.router, self.networks,
                              self.instance_keypair, self.security_group)
 
         # Get DHCP agents for the net9
-        net_id = self.networks[4]
+        net_id = self.networks[8]
         ports_ids_before = [
             port['id'] for port in self.os_conn.list_ports_for_network(
                 network_id=net_id, device_owner='network:dhcp')]

--- a/mos_tests/nova/nova_test.py
+++ b/mos_tests/nova/nova_test.py
@@ -548,7 +548,7 @@ class NovaIntegrationTests(OpenStackTestCase):
     @pytest.mark.testrail_id('843882')
     def test_boot_instance_from_volume_bigger_than_flavor_size(self):
         """This test checks that nova allows creation instance
-           from volume with size bigger than flavor size
+            from volume with size bigger than flavor size
             Steps:
             1. Create volume with size 2Gb.
             2. Boot instance with flavor size 'tiny' from newly created volume

--- a/mos_tests/nova/nova_test.py
+++ b/mos_tests/nova/nova_test.py
@@ -544,3 +544,60 @@ class NovaIntegrationTests(OpenStackTestCase):
         if loss > 10:
             msg = "Packets loss during stability {}% exceeds the 10% limit"
             raise AssertionError(msg.format(loss))
+
+    @pytest.mark.testrail_id('843882')
+    def test_boot_instance_from_volume_bigger_than_flavor_size(self):
+        """This test checks that nova allows creation instance
+           from volume with size bigger than flavor size
+            Steps:
+            1. Create volume with size 2Gb.
+            2. Boot instance with flavor size 'tiny' from newly created volume
+            3. Check that instance created with correct values
+        """
+
+        # 1. Create volume
+        image_id = [image.id for image in self.nova.images.list() if
+                    image.name == 'TestVM'][0]
+
+        volume = common_functions.create_volume(self.cinder, image_id,
+                                                size=2, timeout=60)
+        self.volumes.append(volume)
+
+        # 2. Create router, network, subnet, connect them to external network
+        exist_networks = self.os_conn.list_networks()['networks']
+        ext_network = [x for x in exist_networks
+                       if x.get('router:external')][0]
+        self.router = self.os_conn.create_router(name="router01")['router']
+        self.os_conn.router_gateway_add(router_id=self.router['id'],
+                                        network_id=ext_network['id'])
+        net_id = self.os_conn.add_net(self.router['id'])
+
+        # 3. Create instance from newly created volume, associate floating_ip
+        name = 'TestVM_1517671_instance'
+        flavor_list = {f.name: f.id for f in self.nova.flavors.list()}
+        initial_flavor = flavor_list['m1.tiny']
+        bdm = {'vda': volume.id}
+        instance = common_functions.create_instance(self.nova, name,
+                                                    initial_flavor, net_id,
+                                                    [self.sec_group.name],
+                                                    block_device_mapping=bdm,
+                                                    inst_list=self.instances)
+        self.instances.append(instance.id)
+
+        # Assert for attached volumes
+        attached_volumes = self.nova.servers.get(instance).to_dict()[
+            'os-extended-volumes:volumes_attached']
+        self.assertIn({'id': volume.id}, attached_volumes)
+
+        # Assert to flavor size
+        self.assertEqual(self.nova.servers.get(instance).flavor['id'],
+                         initial_flavor,
+                         "Unexpected instance flavor after creation")
+
+        floating_ip = self.nova.floating_ips.create()
+        self.floating_ips.append(floating_ip.ip)
+        instance.add_floating_ip(floating_ip.ip)
+
+        # Check that instance is reachable
+        ping = common_functions.ping_command(self.floating_ip.ip)
+        self.assertTrue(ping, "Instance after creation is not reachable")


### PR DESCRIPTION
Test automation for the bug
Function create_networks() is moved to BaseTest object to be used in several test cases from different test groups.
